### PR TITLE
Roller med nye navn

### DIFF
--- a/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
+++ b/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
@@ -1,7 +1,7 @@
 package no.difi.sdp.client2;
 
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.Forsendelse;
-import no.difi.sdp.client2.domain.TekniskAvsender;
 import no.difi.sdp.client2.domain.exceptions.SendException;
 import no.difi.sdp.client2.domain.kvittering.ForretningsKvittering;
 import no.difi.sdp.client2.domain.kvittering.KvitteringForespoersel;
@@ -16,26 +16,26 @@ import no.digipost.api.representations.KanBekreftesSomBehandletKvittering;
 
 public class SikkerDigitalPostKlient {
 
-    private final TekniskAvsender tekniskAvsender;
+    private final Databehandler databehandler;
     private final EbmsForsendelseBuilder ebmsForsendelseBuilder;
     private final KvitteringBuilder kvitteringBuilder;
     private final DigipostMessageSenderFacade digipostMessageSenderFacade;
     private final KlientKonfigurasjon klientKonfigurasjon;
 
     /**
-     * @param tekniskAvsender     teknisk avsender er den parten som har ansvarlig for den tekniske utførelsen av sendingen.
+     * @param databehandler       parten som har ansvarlig for den tekniske utførelsen av sendingen.
      *                            Se <a href="http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer">oversikt over aktører</a> for mer informasjon.
      * @param klientKonfigurasjon Oppsett for blant annet oppkoblingen mot meldingsformidler og interceptorer for å få ut data som sendes.
      */
-    public SikkerDigitalPostKlient(TekniskAvsender tekniskAvsender, KlientKonfigurasjon klientKonfigurasjon) {
+    public SikkerDigitalPostKlient(Databehandler databehandler, KlientKonfigurasjon klientKonfigurasjon) {
         CryptoChecker.checkCryptoPolicy();
 
         this.ebmsForsendelseBuilder = new EbmsForsendelseBuilder();
         this.kvitteringBuilder = new KvitteringBuilder();
-        this.digipostMessageSenderFacade = new DigipostMessageSenderFacade(tekniskAvsender, klientKonfigurasjon);
+        this.digipostMessageSenderFacade = new DigipostMessageSenderFacade(databehandler, klientKonfigurasjon);
 
         this.klientKonfigurasjon = klientKonfigurasjon;
-        this.tekniskAvsender = tekniskAvsender;
+        this.databehandler = databehandler;
     }
 
     /**
@@ -46,7 +46,7 @@ public class SikkerDigitalPostKlient {
      * @throws SendException
      */
     public void send(Forsendelse forsendelse) throws SendException {
-        EbmsForsendelse ebmsForsendelse = ebmsForsendelseBuilder.buildEbmsForsendelse(tekniskAvsender, klientKonfigurasjon.getMeldingsformidlerOrganisasjon(), forsendelse);
+        EbmsForsendelse ebmsForsendelse = ebmsForsendelseBuilder.buildEbmsForsendelse(databehandler, klientKonfigurasjon.getMeldingsformidlerOrganisasjon(), forsendelse);
         digipostMessageSenderFacade.send(ebmsForsendelse);
     }
 

--- a/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
+++ b/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
@@ -7,7 +7,7 @@ import no.difi.sdp.client2.asice.manifest.Manifest;
 import no.difi.sdp.client2.asice.signature.CreateSignature;
 import no.difi.sdp.client2.asice.signature.Signature;
 import no.difi.sdp.client2.domain.Forsendelse;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ public class CreateASiCE {
         createZip = new CreateZip();
     }
 
-    public ArchivedASiCE createAsice(TekniskAvsender tekniskAvsender, Forsendelse forsendelse) {
+    public ArchivedASiCE createAsice(Databehandler databehandler, Forsendelse forsendelse) {
         // Lag ASiC-E manifest
         log.info("Creating ASiC-E manifest");
         Manifest manifest = createManifest.createManifest(forsendelse);
@@ -46,8 +46,8 @@ public class CreateASiCE {
         files.add(manifest);
 
         // Lag signatur over alle filene i pakka
-        log.info("Signing ASiC-E documents using private key with alias " + tekniskAvsender.noekkelpar.getAlias());
-        Signature signature = createSignature.createSignature(tekniskAvsender.noekkelpar, files);
+        log.info("Signing ASiC-E documents using private key with alias " + databehandler.noekkelpar.getAlias());
+        Signature signature = createSignature.createSignature(databehandler.noekkelpar, files);
         files.add(signature);
 
         // Zip filene

--- a/src/main/java/no/difi/sdp/client2/domain/Avsender.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Avsender.java
@@ -1,15 +1,17 @@
 package no.difi.sdp.client2.domain;
 
-/**
- * Behandlingsansvarlig som beskrevet i <a href="http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer">oversikten over aktører</a>.
- */
-public class Behandlingsansvarlig {
+import no.digipost.api.representations.Organisasjonsnummer;
 
-    private final String organisasjonsnummer;
+/**
+ * Avsender som beskrevet i <a href="http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer">oversikten over aktører</a>.
+ */
+public class Avsender {
+
+    private final Organisasjonsnummer organisasjonsnummer;
     private String avsenderIdentifikator;
     private String fakturaReferanse;
 
-    public Behandlingsansvarlig(String organisasjonsnummer) {
+    public Avsender(Organisasjonsnummer organisasjonsnummer) {
         this.organisasjonsnummer = organisasjonsnummer;
     }
 
@@ -21,21 +23,21 @@ public class Behandlingsansvarlig {
         return fakturaReferanse;
     }
 
-    public String getOrganisasjonsnummer() {
+    public Organisasjonsnummer getOrganisasjonsnummer() {
         return organisasjonsnummer;
     }
 
-    public static Builder builder(String organisasjonsnummer) {
+    public static Builder builder(Organisasjonsnummer organisasjonsnummer) {
         return new Builder(organisasjonsnummer);
     }
 
     public static class Builder {
 
-        private final Behandlingsansvarlig target;
+        private final Avsender target;
         private boolean built = false;
 
-        private Builder(String organisasjonsnummer) {
-            target = new Behandlingsansvarlig(organisasjonsnummer);
+        private Builder(Organisasjonsnummer organisasjonsnummer) {
+            target = new Avsender(organisasjonsnummer);
         }
 
         public Builder fakturaReferanse(String fakturaReferanse) {
@@ -53,7 +55,7 @@ public class Behandlingsansvarlig {
             return this;
         }
 
-        public Behandlingsansvarlig build() {
+        public Avsender build() {
             if (built) throw new IllegalStateException("Can't build twice");
             built = true;
             return this.target;

--- a/src/main/java/no/difi/sdp/client2/domain/Databehandler.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Databehandler.java
@@ -2,12 +2,12 @@ package no.difi.sdp.client2.domain;
 
 import no.digipost.api.representations.Organisasjonsnummer;
 
-public class TekniskAvsender {
+public class Databehandler {
 
     public final Organisasjonsnummer organisasjonsnummer;
     public final Noekkelpar noekkelpar;
 
-    private TekniskAvsender(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
+    private Databehandler(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
 
         this.organisasjonsnummer = organisasjonsnummer;
         this.noekkelpar = noekkelpar;
@@ -23,14 +23,14 @@ public class TekniskAvsender {
 
     public static class Builder {
 
-        private final TekniskAvsender target;
+        private final Databehandler target;
         private boolean built = false;
 
         private Builder(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
-            target = new TekniskAvsender(organisasjonsnummer, noekkelpar);
+            target = new Databehandler(organisasjonsnummer, noekkelpar);
         }
 
-        public TekniskAvsender build() {
+        public Databehandler build() {
             if (built) throw new IllegalStateException("Can't build twice");
             built = true;
             return this.target;

--- a/src/main/java/no/difi/sdp/client2/domain/Forsendelse.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Forsendelse.java
@@ -26,23 +26,23 @@ public class Forsendelse {
     private final DigitalPost digitalPost;
     private final FysiskPost fysiskPost;
     private final Dokumentpakke dokumentpakke;
-    private final Behandlingsansvarlig behandlingsansvarlig;
+    private final Avsender avsender;
     private String konversasjonsId = UUID.randomUUID().toString();
     private Prioritet prioritet = Prioritet.NORMAL;
     private String spraakkode = "NO";
     private String mpcId;
 
-    private Forsendelse(Behandlingsansvarlig behandlingsansvarlig, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
+    private Forsendelse(Avsender avsender, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
     	this.type = DIGITAL;
-        this.behandlingsansvarlig = behandlingsansvarlig;
+        this.avsender = avsender;
         this.digitalPost = digitalPost;
         this.fysiskPost = null;
         this.dokumentpakke = dokumentpakke;
     }
 
-    private Forsendelse(Behandlingsansvarlig behandlingsansvarlig, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
+    private Forsendelse(Avsender avsender, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
     	this.type = FYSISK;
-    	this.behandlingsansvarlig = behandlingsansvarlig;
+    	this.avsender = avsender;
     	this.dokumentpakke = dokumentpakke;
     	this.fysiskPost = fysiskPost;
     	this.digitalPost = null;
@@ -76,22 +76,22 @@ public class Forsendelse {
         return mpcId;
     }
 
-    public Behandlingsansvarlig getBehandlingsansvarlig() {
-        return behandlingsansvarlig;
+    public Avsender getAvsender() {
+        return avsender;
     }
 
     /**
-     * @param behandlingsansvarlig Ansvarlig avsender av forsendelsen. Dette vil i de aller fleste tilfeller være
+     * @param avsender Ansvarlig avsender av forsendelsen. Dette vil i de aller fleste tilfeller være
      *                             den offentlige virksomheten som er ansvarlig for brevet som skal sendes.
      * @param digitalPost Informasjon som brukes av postkasseleverandør for å behandle den digitale posten.
      * @param dokumentpakke Pakke med hoveddokument og evt vedlegg som skal sendes.
      */
-    public static Builder digital(Behandlingsansvarlig behandlingsansvarlig, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
-        return new Builder(behandlingsansvarlig, digitalPost, dokumentpakke);
+    public static Builder digital(Avsender avsender, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
+        return new Builder(avsender, digitalPost, dokumentpakke);
     }
 
-	public static Builder fysisk(Behandlingsansvarlig behandlingsansvarlig, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
-	    return new Builder(behandlingsansvarlig, fysiskPost, dokumentpakke);
+	public static Builder fysisk(Avsender avsender, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
+	    return new Builder(avsender, fysiskPost, dokumentpakke);
     }
 
     public static class Builder {
@@ -99,12 +99,12 @@ public class Forsendelse {
         private final Forsendelse target;
         private boolean built = false;
 
-        private Builder(Behandlingsansvarlig behandlingsansvarlig, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
-            this.target = new Forsendelse(behandlingsansvarlig, digitalPost, dokumentpakke);
+        private Builder(Avsender avsender, DigitalPost digitalPost, Dokumentpakke dokumentpakke) {
+            this.target = new Forsendelse(avsender, digitalPost, dokumentpakke);
         }
 
-        private Builder(Behandlingsansvarlig behandlingsansvarlig, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
-            this.target = new Forsendelse(behandlingsansvarlig, fysiskPost, dokumentpakke);
+        private Builder(Avsender avsender, FysiskPost fysiskPost, Dokumentpakke dokumentpakke) {
+            this.target = new Forsendelse(avsender, fysiskPost, dokumentpakke);
         }
 
         /**

--- a/src/main/java/no/difi/sdp/client2/domain/digital_post/DigitalPost.java
+++ b/src/main/java/no/difi/sdp/client2/domain/digital_post/DigitalPost.java
@@ -48,7 +48,7 @@ public class DigitalPost {
     }
 
     /**
-     * @param mottaker Mottaker av digital post.
+     * @param mottaker           Mottaker av digital post.
      * @param ikkeSensitivTittel Ikke-sensitiv tittel på brevet.
      *                           Denne tittelen vil være synlig under transport av meldingen og kan vises i mottakerens postkasse selv om det ikke er autentisert med tilstrekkelig autentiseringsnivå.
      */
@@ -67,7 +67,7 @@ public class DigitalPost {
 
         /**
          * Når brevet tilgjengeliggjøres for mottaker.
-         *
+         * <p>
          * Standard er nå.
          */
         public Builder virkningsdato(Date virkningsdato) {
@@ -77,7 +77,7 @@ public class DigitalPost {
 
         /**
          * Ønskes kvittering når brevet blir åpnet av mottaker?
-         *
+         * <p>
          * Standard er false.
          */
         public Builder aapningskvittering(boolean aapningskvittering) {
@@ -87,7 +87,7 @@ public class DigitalPost {
 
         /**
          * Nødvendig autentiseringsnivå som kreves av mottaker i postkassen for å åpne brevet.
-         *
+         * <p>
          * Standard er {@link Sikkerhetsnivaa#NIVAA_4}.
          */
         public Builder sikkerhetsnivaa(Sikkerhetsnivaa sikkerhetsnivaa) {
@@ -97,7 +97,7 @@ public class DigitalPost {
 
         /**
          * Minimum e-postvarsel som skal sendes til mottaker av brevet. Postkassen kan velge å sende andre varsler i tillegg.
-         *
+         * <p>
          * Standard er standardoppførselen til postkasseleverandøren.
          */
         public Builder epostVarsel(EpostVarsel epostVarsel) {
@@ -107,7 +107,7 @@ public class DigitalPost {
 
         /**
          * Minimum sms-varsel som skal sendes til mottaker av brevet. Postkassen kan velge å sende andre varsler i tillegg.
-         *
+         * <p>
          * Standard er standardoppførselen til postkasseleverandøren.
          */
         public Builder smsVarsel(SmsVarsel smsVarsel) {

--- a/src/main/java/no/difi/sdp/client2/domain/fysisk_post/FysiskPost.java
+++ b/src/main/java/no/difi/sdp/client2/domain/fysisk_post/FysiskPost.java
@@ -2,89 +2,79 @@ package no.difi.sdp.client2.domain.fysisk_post;
 
 import no.difi.sdp.client2.domain.TekniskMottaker;
 
-
-
 public class FysiskPost {
 
-	private KonvoluttAdresse adressat;
-	private Posttype posttype;
-	private Utskriftsfarge utskriftsfarge;
-	private Returhaandtering returhaandtering;
-	private KonvoluttAdresse returadresse;
-	private TekniskMottaker utskriftsleverandoer;
+    private KonvoluttAdresse adressat;
+    private Posttype posttype;
+    private Utskriftsfarge utskriftsfarge;
+    private Returhaandtering returhaandtering;
+    private KonvoluttAdresse returadresse;
+    private TekniskMottaker utskriftsleverandoer;
 
+    public KonvoluttAdresse getAdresse() {
+        return adressat;
+    }
 
-	public KonvoluttAdresse getAdresse() {
-		return adressat;
-	}
+    public Posttype getPosttype() {
+        return posttype;
+    }
 
-	public Posttype getPosttype() {
-		return posttype;
-	}
+    public Utskriftsfarge getUtskriftsfarge() {
+        return utskriftsfarge;
+    }
 
-	public Utskriftsfarge getUtskriftsfarge() {
-		return utskriftsfarge;
-	}
+    public Returhaandtering getReturhaandtering() {
+        return returhaandtering;
+    }
 
-	public Returhaandtering getReturhaandtering() {
-		return returhaandtering;
-	}
+    public KonvoluttAdresse getReturadresse() {
+        return returadresse;
+    }
 
-	public KonvoluttAdresse getReturadresse() {
-		return returadresse;
-	}
+    public TekniskMottaker getUtskriftsleverandoer() {
+        return utskriftsleverandoer;
+    }
 
-	public TekniskMottaker getUtskriftsleverandoer() {
-		return utskriftsleverandoer;
-	}
+    public static FysiskPost.Builder builder() {
+        return new Builder();
+    }
 
-	public static FysiskPost.Builder builder() {
-		return new Builder();
-	}
+    public static final class Builder {
 
+        private final FysiskPost fysiskPost;
+        private boolean built = false;
 
+        private Builder() {
+            fysiskPost = new FysiskPost();
+        }
 
+        public Builder adresse(KonvoluttAdresse adresse) {
+            fysiskPost.adressat = adresse;
+            return this;
+        }
 
-	public static final class Builder {
+        public Builder sendesMed(Posttype posttype) {
+            fysiskPost.posttype = posttype;
+            return this;
+        }
 
-		private final FysiskPost fysiskPost;
-		private boolean built = false;
+        public Builder utskrift(Utskriftsfarge utskriftsfarge, TekniskMottaker utskriftsleverandoer) {
+            fysiskPost.utskriftsfarge = utskriftsfarge;
+            fysiskPost.utskriftsleverandoer = utskriftsleverandoer;
+            return this;
+        }
 
-		private Builder() {
-			fysiskPost = new FysiskPost();
-		}
+        public Builder retur(Returhaandtering haandtering, KonvoluttAdresse returadresse) {
+            fysiskPost.returhaandtering = haandtering;
+            fysiskPost.returadresse = returadresse;
+            return this;
+        }
 
-		public Builder adresse(KonvoluttAdresse adresse) {
-			fysiskPost.adressat = adresse;
-			return this;
-		}
-
-		public Builder sendesMed(Posttype posttype) {
-			fysiskPost.posttype = posttype;
-			return this;
-		}
-
-		public Builder utskrift(Utskriftsfarge utskriftsfarge, TekniskMottaker utskriftsleverandoer) {
-			fysiskPost.utskriftsfarge = utskriftsfarge;
-			fysiskPost.utskriftsleverandoer = utskriftsleverandoer;
-			return this;
-		}
-
-		public Builder retur(Returhaandtering haandtering, KonvoluttAdresse returadresse) {
-			fysiskPost.returhaandtering = haandtering;
-			fysiskPost.returadresse = returadresse;
-			return this;
-		}
-
-		public FysiskPost build() {
-			if (built) throw new IllegalStateException("Can't build twice");
+        public FysiskPost build() {
+            if (built) throw new IllegalStateException("Can't build twice");
             built = true;
             return fysiskPost;
-		}
+        }
 
-	}
-
-
-
-
+    }
 }

--- a/src/main/java/no/difi/sdp/client2/internal/CreateDokumentpakke.java
+++ b/src/main/java/no/difi/sdp/client2/internal/CreateDokumentpakke.java
@@ -4,7 +4,7 @@ import no.difi.sdp.client2.asice.ArchivedASiCE;
 import no.difi.sdp.client2.asice.CreateASiCE;
 import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.Sertifikat;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.digipost.api.representations.Dokumentpakke;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,9 +21,9 @@ public class CreateDokumentpakke {
         createCMS = new CreateCMSDocument();
     }
 
-    public Dokumentpakke createDokumentpakke(TekniskAvsender tekniskAvsender, Forsendelse forsendelse) {
+    public Dokumentpakke createDokumentpakke(Databehandler databehandler, Forsendelse forsendelse) {
         log.info("Creating dokumentpakke");
-        ArchivedASiCE archivedASiCE = createASiCE.createAsice(tekniskAvsender, forsendelse);
+        ArchivedASiCE archivedASiCE = createASiCE.createAsice(databehandler, forsendelse);
 
         Sertifikat mottakerSertifikat = forsendelse.getTekniskMottaker().sertifikat;
 

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -2,7 +2,7 @@ package no.difi.sdp.client2.internal;
 
 import no.difi.sdp.client2.ExceptionMapper;
 import no.difi.sdp.client2.KlientKonfigurasjon;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.exceptions.KonfigurasjonException;
 import no.difi.sdp.client2.domain.exceptions.SendException;
 import no.difi.sdp.client2.domain.exceptions.XmlValideringException;
@@ -35,15 +35,15 @@ public class DigipostMessageSenderFacade {
     private ExceptionMapper exceptionMapper = new ExceptionMapper();
 
 
-    public DigipostMessageSenderFacade(final TekniskAvsender tekniskAvsender, final KlientKonfigurasjon klientKonfigurasjon) {
-        KeyStoreInfo keyStoreInfo = tekniskAvsender.noekkelpar.getKeyStoreInfo();
+    public DigipostMessageSenderFacade(final Databehandler databehandler, final KlientKonfigurasjon klientKonfigurasjon) {
+        KeyStoreInfo keyStoreInfo = databehandler.noekkelpar.getKeyStoreInfo();
         WsSecurityInterceptor wsSecurityInterceptor = new WsSecurityInterceptor(keyStoreInfo, new UserFriendlyWsSecurityExceptionMapper());
         wsSecurityInterceptor.afterPropertiesSet();
 
-        MessageSender.Builder messageSenderBuilder = MessageSender.create(new MeldingsformidlerUri(klientKonfigurasjon.getMeldingsformidlerRoot(), tekniskAvsender.organisasjonsnummer),
+        MessageSender.Builder messageSenderBuilder = MessageSender.create(new MeldingsformidlerUri(klientKonfigurasjon.getMeldingsformidlerRoot(), databehandler.organisasjonsnummer),
                 keyStoreInfo,
                 wsSecurityInterceptor,
-                EbmsAktoer.avsender(tekniskAvsender.organisasjonsnummer),
+                EbmsAktoer.avsender(databehandler.organisasjonsnummer),
                 EbmsAktoer.meldingsformidler(klientKonfigurasjon.getMeldingsformidlerOrganisasjon()))
                 .withConnectTimeout((int) klientKonfigurasjon.getConnectTimeoutInMillis())
                 .withSocketTimeout((int) klientKonfigurasjon.getSocketTimeoutInMillis())

--- a/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
@@ -2,7 +2,7 @@ package no.difi.sdp.client2.internal;
 
 import no.difi.begrep.sdp.schema_v10.SDPDigitalPost;
 import no.difi.sdp.client2.domain.Forsendelse;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.TekniskMottaker;
 import no.digipost.api.representations.*;
 import org.joda.time.DateTime;
@@ -20,22 +20,22 @@ public class EbmsForsendelseBuilder {
         createDokumentpakke = new CreateDokumentpakke();
     }
 
-    public EbmsForsendelse buildEbmsForsendelse(TekniskAvsender tekniskAvsender, Organisasjonsnummer meldingsformidler, Forsendelse forsendelse) {
+    public EbmsForsendelse buildEbmsForsendelse(Databehandler databehandler, Organisasjonsnummer meldingsformidler, Forsendelse forsendelse) {
         TekniskMottaker mottaker = forsendelse.getTekniskMottaker();
 
         //EBMS
-        EbmsAktoer ebmsAvsender = EbmsAktoer.avsender(tekniskAvsender.organisasjonsnummer);
+        EbmsAktoer ebmsAvsender = EbmsAktoer.avsender(databehandler.organisasjonsnummer);
         EbmsAktoer ebmsMottaker = EbmsAktoer.meldingsformidler(meldingsformidler);
 
         //SBD
         String meldingsId = UUID.randomUUID().toString();
         Organisasjonsnummer sbdhMottaker = mottaker.organisasjonsnummer;
-        Organisasjonsnummer sbdhAvsender = tekniskAvsender.organisasjonsnummer;
+        Organisasjonsnummer sbdhAvsender = databehandler.organisasjonsnummer;
         SDPDigitalPost sikkerDigitalPost = sdpBuilder.buildDigitalPost(forsendelse);
         StandardBusinessDocument standardBusinessDocument = StandardBusinessDocumentFactory.create(sbdhAvsender, sbdhMottaker, meldingsId, DateTime.now(),forsendelse.getKonversasjonsId(), sikkerDigitalPost);
 
         //Dokumentpakke
-        Dokumentpakke dokumentpakke = createDokumentpakke.createDokumentpakke(tekniskAvsender, forsendelse);
+        Dokumentpakke dokumentpakke = createDokumentpakke.createDokumentpakke(databehandler, forsendelse);
 
         return EbmsForsendelse.create(ebmsAvsender, ebmsMottaker, sbdhMottaker, standardBusinessDocument, dokumentpakke)
                 .withPrioritet(forsendelse.getPrioritet().getEbmsPrioritet())

--- a/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
@@ -1,7 +1,7 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.begrep.sdp.schema_v10.*;
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.digital_post.DigitalPost;
@@ -31,7 +31,7 @@ public class SDPBuilder {
 
     public SDPManifest createManifest(final Forsendelse forsendelse) {
         SDPMottaker sdpMottaker = sdpMottaker(forsendelse.getDigitalPost());
-        SDPAvsender sdpAvsender = sdpAvsender(forsendelse.getBehandlingsansvarlig());
+        SDPAvsender sdpAvsender = sdpAvsender(forsendelse.getAvsender());
         String spraakkode = forsendelse.getSpraakkode();
         SDPDokument sdpHovedDokument = sdpDokument(forsendelse.getDokumentpakke().getHoveddokument(), spraakkode);
 
@@ -44,7 +44,7 @@ public class SDPBuilder {
     }
 
     public SDPDigitalPost buildDigitalPost(final Forsendelse forsendelse) {
-        SDPAvsender sdpAvsender = sdpAvsender(forsendelse.getBehandlingsansvarlig());
+        SDPAvsender sdpAvsender = sdpAvsender(forsendelse.getAvsender());
         SDPMottaker sdpMottaker = sdpMottaker(forsendelse.getDigitalPost());
 
         SDPDigitalPostInfo sdpDigitalPostInfo = sdpDigitalPostinfo(forsendelse);
@@ -70,7 +70,7 @@ public class SDPBuilder {
         return new SDPMottaker(sdpPerson);
     }
 
-    private SDPAvsender sdpAvsender(final Behandlingsansvarlig avsender) {
+    private SDPAvsender sdpAvsender(final Avsender avsender) {
         String fakturaReferanse = avsender.getFakturaReferanse();
         String identifikator = avsender.getAvsenderIdentifikator();
         SDPOrganisasjon organisasjon = sdpOrganisasjon(avsender);
@@ -78,7 +78,7 @@ public class SDPBuilder {
         return new SDPAvsender(organisasjon, identifikator, fakturaReferanse);
     }
 
-    private SDPOrganisasjon sdpOrganisasjon(final Behandlingsansvarlig avsender) {
+    private SDPOrganisasjon sdpOrganisasjon(final Avsender avsender) {
         return new SDPOrganisasjon(ORGNR_IDENTIFIER + avsender.getOrganisasjonsnummer(), SDPIso6523Authority.ISO_6523_ACTORID_UPIS);
     }
 

--- a/src/test/java/no/difi/sdp/client2/KlientKonfigurasjonTest.java
+++ b/src/test/java/no/difi/sdp/client2/KlientKonfigurasjonTest.java
@@ -1,6 +1,7 @@
 package no.difi.sdp.client2;
 
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
+import no.digipost.api.representations.Organisasjonsnummer;
 import org.junit.Test;
 
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -10,7 +11,7 @@ public class KlientKonfigurasjonTest {
     @Test
     public void default_builder_initializes_meldingsformidler_root() {
         String meldingsformidlerRoot =  "http://meldingsformidlerroot.no";
-        Behandlingsansvarlig behandlingsansvarlig = Behandlingsansvarlig.builder("orgnummer").build();
+        Avsender avsender = Avsender.builder(Organisasjonsnummer.of("984661185")).build();
 
         KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon
                 .builder(meldingsformidlerRoot)

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -58,9 +58,9 @@ public class ObjectMother {
                 .vedlegg(new ArrayList<Dokument>())
                 .build();
 
-        Behandlingsansvarlig behandlingsansvarlig = behandlingsansvarlig();
+        Avsender avsender = avsender();
 
-        return Forsendelse.digital(behandlingsansvarlig, digitalPost, dokumentpakke)
+        return Forsendelse.digital(avsender, digitalPost, dokumentpakke)
                 .konversasjonsId(UUID.randomUUID().toString())
                 .prioritet(Prioritet.PRIORITERT)
                 .spraakkode("NO")
@@ -89,8 +89,8 @@ public class ObjectMother {
                 .build();
     }
 
-    public static Behandlingsansvarlig behandlingsansvarlig() {
-        return Behandlingsansvarlig.builder("984661185")
+    public static Avsender avsender() {
+        return Avsender.builder(Organisasjonsnummer.of("984661185"))
                 .avsenderIdentifikator("avsenderId")
                 .fakturaReferanse("ØK1")
                 .build();

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -96,13 +96,13 @@ public class ObjectMother {
                 .build();
     }
 
-    public static TekniskAvsender tekniskAvsender() {
-        return TekniskAvsender.builder(Organisasjonsnummer.of("984661185"), noekkelpar())
+    public static Databehandler databehandler() {
+        return Databehandler.builder(Organisasjonsnummer.of("984661185"), noekkelpar())
                 .build();
     }
 
-    public static TekniskAvsender tekniskAvsenderMedSertifikat(final Noekkelpar noekkelpar) {
-        return TekniskAvsender.builder(Organisasjonsnummer.of("984661185"), noekkelpar)
+    public static Databehandler databehandlerMedSertifikat(final Noekkelpar noekkelpar) {
+        return Databehandler.builder(Organisasjonsnummer.of("984661185"), noekkelpar)
                 .build();
     }
 

--- a/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
+++ b/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
@@ -1,6 +1,5 @@
 package no.difi.sdp.client2;
 
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
 import no.difi.sdp.client2.domain.exceptions.SendIOException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;

--- a/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
+++ b/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static no.difi.sdp.client2.ObjectMother.forsendelse;
-import static no.difi.sdp.client2.ObjectMother.tekniskAvsender;
+import static no.difi.sdp.client2.ObjectMother.databehandler;
 import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.UKJENT;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Fail.fail;
@@ -26,7 +26,7 @@ public class SikkerDigitalPostKlientTest {
                 .connectionTimeout(1, TimeUnit.MILLISECONDS)
                 .build();
 
-        SikkerDigitalPostKlient postklient = new SikkerDigitalPostKlient(tekniskAvsender(), klientKonfigurasjon);
+        SikkerDigitalPostKlient postklient = new SikkerDigitalPostKlient(databehandler(), klientKonfigurasjon);
 
         try {
             postklient.send(forsendelse());
@@ -57,7 +57,7 @@ public class SikkerDigitalPostKlientTest {
                 })
                 .build();
 
-        SikkerDigitalPostKlient postklient = new SikkerDigitalPostKlient(tekniskAvsender(), klientKonfigurasjon);
+        SikkerDigitalPostKlient postklient = new SikkerDigitalPostKlient(databehandler(), klientKonfigurasjon);
 
         try {
             postklient.send(forsendelse());

--- a/src/test/java/no/difi/sdp/client2/asice/manifest/CreateManifestTest.java
+++ b/src/test/java/no/difi/sdp/client2/asice/manifest/CreateManifestTest.java
@@ -1,7 +1,7 @@
 package no.difi.sdp.client2.asice.manifest;
 
 import no.difi.sdp.client2.ObjectMother;
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.Mottaker;
 import no.difi.sdp.client2.domain.digital_post.DigitalPost;
@@ -31,7 +31,7 @@ public class CreateManifestTest {
     @Test(expected = XmlValideringException.class)
     public void should_validate_manifest() {
         Mottaker mottaker = Mottaker.builder("04036125433", null, mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
-        Behandlingsansvarlig behandlingsasnvarlig = Behandlingsansvarlig.builder("991825827").build();
+        Avsender behandlingsasnvarlig = Avsender.builder(Organisasjonsnummer.of("991825827")).build();
         Forsendelse ugyldigForsendelse = Forsendelse.digital(behandlingsasnvarlig, DigitalPost.builder(mottaker, "tittel").build(), ObjectMother.dokumentpakke()).build();
 
         sut.createManifest(ugyldigForsendelse);

--- a/src/test/java/no/difi/sdp/client2/domain/ForsendelseTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/ForsendelseTest.java
@@ -37,9 +37,9 @@ public class ForsendelseTest {
                 .vedlegg(new ArrayList<Dokument>())
                 .build();
 
-        Behandlingsansvarlig behandlingsansvarlig = ObjectMother.behandlingsansvarlig();
+        Avsender avsender = ObjectMother.avsender();
 
-        forsendelse = Forsendelse.digital(behandlingsansvarlig, digitalPost, dokumentpakke)
+        forsendelse = Forsendelse.digital(avsender, digitalPost, dokumentpakke)
                 .build();
     }
 
@@ -65,7 +65,7 @@ public class ForsendelseTest {
     			.retur(Returhaandtering.MAKULERING_MED_MELDING, KonvoluttAdresse.build("Rall").iUtlandet("Hungary street 2", null, null, null, "Ungarn").build())
     			.sendesMed(Posttype.A_PRIORITERT)
     			.utskrift(Utskriftsfarge.FARGE, new TekniskMottaker(Organisasjonsnummer.of("988015814"), null)).build();
-		Forsendelse fysiskForsendelse = Forsendelse.fysisk(ObjectMother.behandlingsansvarlig(), adresse,
+		Forsendelse fysiskForsendelse = Forsendelse.fysisk(ObjectMother.avsender(), adresse,
     			Dokumentpakke.builder(Dokument.builder("Sensitiv brevtittel", "faktura.pdf", new ByteArrayInputStream("hei".getBytes())).build()).build()).build();
 
 		assertThat(fysiskForsendelse.type).isEqualTo(Forsendelse.Type.FYSISK);

--- a/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
+++ b/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
@@ -2,7 +2,7 @@ package no.difi.sdp.client2.internal;
 
 import no.difi.sdp.client2.ObjectMother;
 import no.difi.sdp.client2.domain.Behandlingsansvarlig;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -31,7 +31,7 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void bygg_minimalt_request() {
-        TekniskAvsender avsender = TekniskAvsender.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler avsender = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
         Dokument dokument = Dokument.builder("Sensitiv tittel", "filnavn", new ByteArrayInputStream("hei".getBytes())).build();
@@ -47,7 +47,7 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void korrekt_mpc() {
-        TekniskAvsender avsender = TekniskAvsender.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler avsender = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
         Behandlingsansvarlig behandlingsansvarlig = Behandlingsansvarlig.builder("991825827").build();

--- a/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
+++ b/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
@@ -1,7 +1,7 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.sdp.client2.ObjectMother;
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
@@ -31,15 +31,15 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void bygg_minimalt_request() {
-        Databehandler avsender = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler databehandler = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
         Dokument dokument = Dokument.builder("Sensitiv tittel", "filnavn", new ByteArrayInputStream("hei".getBytes())).build();
         Dokumentpakke dokumentpakke = Dokumentpakke.builder(dokument).build();
-        Behandlingsansvarlig behandlingsansvarlig = Behandlingsansvarlig.builder("936796702").build();
-        Forsendelse forsendelse = Forsendelse.digital(behandlingsansvarlig, digitalpost, dokumentpakke).build();
+        Avsender avsender = Avsender.builder(Organisasjonsnummer.of("936796702")).build();
+        Forsendelse forsendelse = Forsendelse.digital(avsender, digitalpost, dokumentpakke).build();
 
-        EbmsForsendelse ebmsForsendelse = sut.buildEbmsForsendelse(avsender, Organisasjonsnummer.of("984661185"), forsendelse);
+        EbmsForsendelse ebmsForsendelse = sut.buildEbmsForsendelse(databehandler, Organisasjonsnummer.of("984661185"), forsendelse);
 
         assertThat(ebmsForsendelse.getAvsender().orgnr.medLandkode()).isEqualTo("9908:991825827");
         assertThat(ebmsForsendelse.getDokumentpakke().getContentType()).isEqualTo("application/cms");
@@ -47,13 +47,13 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void korrekt_mpc() {
-        Databehandler avsender = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler databehandler = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
-        Behandlingsansvarlig behandlingsansvarlig = Behandlingsansvarlig.builder("991825827").build();
-        Forsendelse forsendelse = Forsendelse.digital(behandlingsansvarlig, digitalpost, ObjectMother.dokumentpakke()).mpcId("mpcId").prioritet(Prioritet.PRIORITERT).build();
+        Avsender avsender = Avsender.builder(Organisasjonsnummer.of("991825827")).build();
+        Forsendelse forsendelse = Forsendelse.digital(avsender, digitalpost, ObjectMother.dokumentpakke()).mpcId("mpcId").prioritet(Prioritet.PRIORITERT).build();
 
-        EbmsForsendelse ebmsForsendelse = sut.buildEbmsForsendelse(avsender, Organisasjonsnummer.of("984661185"), forsendelse);
+        EbmsForsendelse ebmsForsendelse = sut.buildEbmsForsendelse(databehandler, Organisasjonsnummer.of("984661185"), forsendelse);
 
         assertThat(ebmsForsendelse.prioritet).isEqualTo(EbmsOutgoingMessage.Prioritet.PRIORITERT);
         assertThat(ebmsForsendelse.mpcId).isEqualTo("mpcId");

--- a/src/test/java/no/difi/sdp/client2/internal/SDPBuilderManifestTest.java
+++ b/src/test/java/no/difi/sdp/client2/internal/SDPBuilderManifestTest.java
@@ -1,7 +1,7 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.begrep.sdp.schema_v10.SDPManifest;
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -32,22 +32,22 @@ public class SDPBuilderManifestTest {
         marshaller.setMarshallerProperties(Collections.singletonMap(Marshaller.JAXB_FORMATTED_OUTPUT, true));
     }
 
-    private SDPBuilder sut;
+    private SDPBuilder sdpBuilder;
 
     @Before
     public void set_up() throws Exception {
-        sut = new SDPBuilder();
+        sdpBuilder = new SDPBuilder();
     }
 
     @Test
     public void build_expected_manifest() throws Exception {
         String expectedXml = IOUtils.toString(this.getClass().getResourceAsStream("/asic/expected-asic-manifest.xml"));
 
-        Behandlingsansvarlig behandlingsansvarlig = Behandlingsansvarlig.builder("123456789").fakturaReferanse("ØK1").avsenderIdentifikator("0123456789").build();
+        Avsender avsender = Avsender.builder(Organisasjonsnummer.of("123456789")).fakturaReferanse("ØK1").avsenderIdentifikator("0123456789").build();
 
         Mottaker mottaker = Mottaker.builder("11077941012", "123456", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
 
-        Forsendelse forsendelse = Forsendelse.digital(behandlingsansvarlig,
+        Forsendelse forsendelse = Forsendelse.digital(avsender,
                 DigitalPost.builder(mottaker, "Ikke sensitiv tittel").build(),
                 Dokumentpakke.builder(Dokument.builder("Vedtak", "vedtak_2398324.pdf", new ByteArrayInputStream("vedtak".getBytes())).mimeType("application/pdf").build()).
                         vedlegg(
@@ -56,7 +56,7 @@ public class SDPBuilderManifestTest {
                         .build())
                 .build();
 
-        SDPManifest manifest = sut.createManifest(forsendelse);
+        SDPManifest manifest = sdpBuilder.createManifest(forsendelse);
 
         ByteArrayOutputStream xmlBytes = new ByteArrayOutputStream();
         marshaller.marshal(manifest, new StreamResult(xmlBytes));

--- a/src/test/java/no/difi/sdp/client2/smoke/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/smoke/ObjectMother.java
@@ -1,6 +1,6 @@
 package no.difi.sdp.client2.smoke;
 
-import no.difi.sdp.client2.domain.Behandlingsansvarlig;
+import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -35,9 +35,9 @@ public class ObjectMother {
                 .vedlegg(new ArrayList<Dokument>())
                 .build();
 
-        Behandlingsansvarlig behandlingsansvarlig = behandlingsansvarlig(orgNumber);
+        Avsender avsender = avsender(orgNumber);
 
-        return Forsendelse.digital(behandlingsansvarlig, digitalPost, dokumentpakke)
+        return Forsendelse.digital(avsender, digitalPost, dokumentpakke)
                 .konversasjonsId(UUID.randomUUID().toString())
                 .prioritet(Prioritet.PRIORITERT)
                 .mpcId(mpcId)
@@ -71,8 +71,8 @@ public class ObjectMother {
     }
 
 
-    public static Behandlingsansvarlig behandlingsansvarlig(final String orgNumber) {
-        return Behandlingsansvarlig.builder(orgNumber)
+    public static Avsender avsender(final String orgNumber) {
+        return Avsender.builder(Organisasjonsnummer.of(orgNumber))
                 .build();
     }
 

--- a/src/test/java/no/difi/sdp/client2/smoke/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/smoke/ObjectMother.java
@@ -8,7 +8,7 @@ import no.difi.sdp.client2.domain.Mottaker;
 import no.difi.sdp.client2.domain.Noekkelpar;
 import no.difi.sdp.client2.domain.Prioritet;
 import no.difi.sdp.client2.domain.Sertifikat;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.digital_post.DigitalPost;
 import no.difi.sdp.client2.domain.digital_post.EpostVarsel;
 import no.difi.sdp.client2.domain.digital_post.Sikkerhetsnivaa;
@@ -45,8 +45,8 @@ public class ObjectMother {
                 .build();
     }
 
-    public static TekniskAvsender tekniskAvsenderMedSertifikat(final Organisasjonsnummer organisasjonsnummer, final Noekkelpar noekkelpar) {
-        return TekniskAvsender.builder(organisasjonsnummer, noekkelpar)
+    public static Databehandler databehandlerMedSertifikat(final Organisasjonsnummer organisasjonsnummer, final Noekkelpar noekkelpar) {
+        return Databehandler.builder(organisasjonsnummer, noekkelpar)
                 .build();
     }
 

--- a/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
+++ b/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
@@ -5,7 +5,7 @@ import no.difi.sdp.client2.SikkerDigitalPostKlient;
 import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.Noekkelpar;
 import no.difi.sdp.client2.domain.Prioritet;
-import no.difi.sdp.client2.domain.TekniskAvsender;
+import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.kvittering.ForretningsKvittering;
 import no.difi.sdp.client2.domain.kvittering.KvitteringForespoersel;
 import no.difi.sdp.client2.domain.kvittering.LeveringsKvittering;
@@ -19,18 +19,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.ws.client.WebServiceClientException;
-import org.springframework.ws.client.support.interceptor.ClientInterceptor;
-import org.springframework.ws.context.MessageContext;
 
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.net.URISyntaxException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
@@ -70,9 +61,9 @@ public class SmokeTest {
                 .connectionTimeout(20, TimeUnit.SECONDS)
                 .build();
 
-        TekniskAvsender tekniskAvsender = ObjectMother.tekniskAvsenderMedSertifikat(Organisasjonsnummer.of("984661185"), avsenderNoekkelpar());
+        Databehandler databehandler = ObjectMother.databehandlerMedSertifikat(Organisasjonsnummer.of("984661185"), avsenderNoekkelpar());
 
-        sikkerDigitalPostKlient = new SikkerDigitalPostKlient(tekniskAvsender, klientKonfigurasjon);
+        sikkerDigitalPostKlient = new SikkerDigitalPostKlient(databehandler, klientKonfigurasjon);
     }
 
     private static void verifyEnvironmentVariables() {


### PR DESCRIPTION
- `TekniskAvsender` -> `Databehandler`
- `Behandlingsansvarlig` -> `Avsender`
- `Avsender.Organisasjonsnummer` er nå typen `Organisasjonsnummer`

Grunnen til dette er at `TekniskAvsender` ikke er et begrep som eksisterer, og vi har ikke implementert `Behandlingsansvarlig` i sin rette form. Den er alltid avsender, og vi kan kalle en skje for en skje!