### PR TITLE
Lager subklasser til Organisasjonsnummer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -27,6 +27,7 @@ This software includes third party software subject to the following licenses:
   FEST Util under Apache License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
+  Hamcrest library under New BSD License
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
   JavaMail 1.4 under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,19 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>no.digipost</groupId>

--- a/src/main/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummer.java
+++ b/src/main/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummer.java
@@ -1,0 +1,17 @@
+package no.difi.sdp.client2.domain;
+
+public interface AktørOrganisasjonsnummer {
+
+    static AktørOrganisasjonsnummer of(String organisasjonsnummer) {
+        return new EtOrganisasjonsnummer(organisasjonsnummer);
+    }
+
+    String getOrganisasjonsnummer();
+
+    String getOrganisasjonsnummerMedLandkode();
+
+    AvsenderOrganisasjonsnummer forfremTilAvsender();
+
+    DatabehandlerOrganisasjonsnummer forfremTilDatabehandler();
+
+}

--- a/src/main/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummer.java
+++ b/src/main/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummer.java
@@ -1,9 +1,15 @@
 package no.difi.sdp.client2.domain;
 
+import no.digipost.api.representations.Organisasjonsnummer;
+
 public interface AktørOrganisasjonsnummer {
 
     static AktørOrganisasjonsnummer of(String organisasjonsnummer) {
         return new EtOrganisasjonsnummer(organisasjonsnummer);
+    }
+
+    static AktørOrganisasjonsnummer of(Organisasjonsnummer organisasjonsnummer) {
+        return new EtOrganisasjonsnummer(organisasjonsnummer.getOrganisasjonsnummer());
     }
 
     String getOrganisasjonsnummer();

--- a/src/main/java/no/difi/sdp/client2/domain/Avsender.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Avsender.java
@@ -1,18 +1,20 @@
 package no.difi.sdp.client2.domain;
 
-import no.digipost.api.representations.Organisasjonsnummer;
-
 /**
  * Avsender som beskrevet i <a href="http://begrep.difi.no/SikkerDigitalPost/forretningslag/Aktorer">oversikten over aktører</a>.
  */
 public class Avsender {
 
-    private final Organisasjonsnummer organisasjonsnummer;
+    private final AvsenderOrganisasjonsnummer organisasjonsnummer;
     private String avsenderIdentifikator;
     private String fakturaReferanse;
 
-    public Avsender(Organisasjonsnummer organisasjonsnummer) {
+    public Avsender(AvsenderOrganisasjonsnummer organisasjonsnummer) {
         this.organisasjonsnummer = organisasjonsnummer;
+    }
+
+    public static Builder builder(AvsenderOrganisasjonsnummer organisasjonsnummer) {
+        return new Builder(organisasjonsnummer);
     }
 
     public String getAvsenderIdentifikator() {
@@ -23,12 +25,8 @@ public class Avsender {
         return fakturaReferanse;
     }
 
-    public Organisasjonsnummer getOrganisasjonsnummer() {
+    public AvsenderOrganisasjonsnummer getOrganisasjonsnummer() {
         return organisasjonsnummer;
-    }
-
-    public static Builder builder(Organisasjonsnummer organisasjonsnummer) {
-        return new Builder(organisasjonsnummer);
     }
 
     public static class Builder {
@@ -36,7 +34,7 @@ public class Avsender {
         private final Avsender target;
         private boolean built = false;
 
-        private Builder(Organisasjonsnummer organisasjonsnummer) {
+        private Builder(AvsenderOrganisasjonsnummer organisasjonsnummer) {
             target = new Avsender(organisasjonsnummer);
         }
 

--- a/src/main/java/no/difi/sdp/client2/domain/AvsenderOrganisasjonsnummer.java
+++ b/src/main/java/no/difi/sdp/client2/domain/AvsenderOrganisasjonsnummer.java
@@ -1,0 +1,5 @@
+package no.difi.sdp.client2.domain;
+
+public interface AvsenderOrganisasjonsnummer extends AktørOrganisasjonsnummer {
+
+}

--- a/src/main/java/no/difi/sdp/client2/domain/Databehandler.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Databehandler.java
@@ -1,13 +1,11 @@
 package no.difi.sdp.client2.domain;
 
-import no.digipost.api.representations.Organisasjonsnummer;
-
 public class Databehandler {
 
-    public final Organisasjonsnummer organisasjonsnummer;
+    public final DatabehandlerOrganisasjonsnummer organisasjonsnummer;
     public final Noekkelpar noekkelpar;
 
-    private Databehandler(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
+    private Databehandler(DatabehandlerOrganisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
 
         this.organisasjonsnummer = organisasjonsnummer;
         this.noekkelpar = noekkelpar;
@@ -15,9 +13,9 @@ public class Databehandler {
 
     /**
      * @param organisasjonsnummer Organisasjonsnummeret til avsender av brevet.
-     * @param noekkelpar Avsenders nøkkelpar: signert virksomhetssertifikat og tilhørende privatnøkkel.
+     * @param noekkelpar          Avsenders nøkkelpar: signert virksomhetssertifikat og tilhørende privatnøkkel.
      */
-    public static Builder builder(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
+    public static Builder builder(DatabehandlerOrganisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
         return new Builder(organisasjonsnummer, noekkelpar);
     }
 
@@ -26,7 +24,7 @@ public class Databehandler {
         private final Databehandler target;
         private boolean built = false;
 
-        private Builder(Organisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
+        private Builder(DatabehandlerOrganisasjonsnummer organisasjonsnummer, Noekkelpar noekkelpar) {
             target = new Databehandler(organisasjonsnummer, noekkelpar);
         }
 

--- a/src/main/java/no/difi/sdp/client2/domain/DatabehandlerOrganisasjonsnummer.java
+++ b/src/main/java/no/difi/sdp/client2/domain/DatabehandlerOrganisasjonsnummer.java
@@ -1,0 +1,5 @@
+package no.difi.sdp.client2.domain;
+
+public interface DatabehandlerOrganisasjonsnummer extends AktørOrganisasjonsnummer {
+
+}

--- a/src/main/java/no/difi/sdp/client2/domain/EtOrganisasjonsnummer.java
+++ b/src/main/java/no/difi/sdp/client2/domain/EtOrganisasjonsnummer.java
@@ -1,0 +1,37 @@
+package no.difi.sdp.client2.domain;
+
+import no.digipost.api.representations.Organisasjonsnummer;
+
+public class EtOrganisasjonsnummer implements AvsenderOrganisasjonsnummer, DatabehandlerOrganisasjonsnummer {
+
+    private Organisasjonsnummer organisasjonsnummer;
+
+    EtOrganisasjonsnummer(String organisasjonsnummer) {
+        this.organisasjonsnummer = Organisasjonsnummer.of(organisasjonsnummer);
+    }
+
+    @Override
+    public String getOrganisasjonsnummer() {
+        return organisasjonsnummer.getOrganisasjonsnummer();
+    }
+
+    @Override
+    public String getOrganisasjonsnummerMedLandkode() {
+        return organisasjonsnummer.getOrganisasjonsnummerMedLandkode();
+    }
+
+    @Override
+    public AvsenderOrganisasjonsnummer forfremTilAvsender() {
+        return this;
+    }
+
+    @Override
+    public DatabehandlerOrganisasjonsnummer forfremTilDatabehandler() {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return organisasjonsnummer.toString();
+    }
+}

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -15,6 +15,7 @@ import no.digipost.api.representations.EbmsApplikasjonsKvittering;
 import no.digipost.api.representations.EbmsForsendelse;
 import no.digipost.api.representations.EbmsPullRequest;
 import no.digipost.api.representations.KanBekreftesSomBehandletKvittering;
+import no.digipost.api.representations.Organisasjonsnummer;
 import no.digipost.api.xml.Schemas;
 import org.apache.http.HttpRequestInterceptor;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
@@ -42,7 +43,7 @@ public class DigipostMessageSenderFacade {
         MessageSender.Builder messageSenderBuilder = MessageSender.create(klientKonfigurasjon.getMeldingsformidlerRoot(),
                 keyStoreInfo,
                 wsSecurityInterceptor,
-                EbmsAktoer.avsender(databehandler.organisasjonsnummer),
+                EbmsAktoer.avsender(Organisasjonsnummer.of(databehandler.organisasjonsnummer.getOrganisasjonsnummer())),
                 EbmsAktoer.meldingsformidler(klientKonfigurasjon.getMeldingsformidlerOrganisasjon()))
                 .withConnectTimeout((int) klientKonfigurasjon.getConnectTimeoutInMillis())
                 .withSocketTimeout((int) klientKonfigurasjon.getSocketTimeoutInMillis())
@@ -108,14 +109,6 @@ public class DigipostMessageSenderFacade {
         }
     }
 
-    private interface VoidRequest {
-        void exec();
-    }
-
-    private interface Request<T> {
-        T exec();
-    }
-
     public void setExceptionMapper(final ExceptionMapper exceptionMapper) {
         this.exceptionMapper = exceptionMapper;
     }
@@ -143,6 +136,14 @@ public class DigipostMessageSenderFacade {
         } catch (Exception e) {
             throw new KonfigurasjonException("Unable to initialize payload validating interecptor", e);
         }
+    }
+
+    private interface VoidRequest {
+        void exec();
+    }
+
+    private interface Request<T> {
+        T exec();
     }
 
 }

--- a/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
@@ -1,10 +1,14 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.begrep.sdp.schema_v10.SDPDigitalPost;
-import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.Databehandler;
+import no.difi.sdp.client2.domain.Forsendelse;
 import no.difi.sdp.client2.domain.TekniskMottaker;
-import no.digipost.api.representations.*;
+import no.digipost.api.representations.Dokumentpakke;
+import no.digipost.api.representations.EbmsAktoer;
+import no.digipost.api.representations.EbmsForsendelse;
+import no.digipost.api.representations.Organisasjonsnummer;
+import no.digipost.api.representations.StandardBusinessDocumentFactory;
 import org.joda.time.DateTime;
 import org.unece.cefact.namespaces.standardbusinessdocumentheader.StandardBusinessDocument;
 
@@ -24,15 +28,15 @@ public class EbmsForsendelseBuilder {
         TekniskMottaker mottaker = forsendelse.getTekniskMottaker();
 
         //EBMS
-        EbmsAktoer ebmsAvsender = EbmsAktoer.avsender(databehandler.organisasjonsnummer);
+        EbmsAktoer ebmsAvsender = EbmsAktoer.avsender(databehandler.organisasjonsnummer.getOrganisasjonsnummer());
         EbmsAktoer ebmsMottaker = EbmsAktoer.meldingsformidler(meldingsformidler);
 
         //SBD
         String meldingsId = UUID.randomUUID().toString();
         Organisasjonsnummer sbdhMottaker = mottaker.organisasjonsnummer;
-        Organisasjonsnummer sbdhAvsender = databehandler.organisasjonsnummer;
+        Organisasjonsnummer sbdhAvsender = Organisasjonsnummer.of(databehandler.organisasjonsnummer.getOrganisasjonsnummer());
         SDPDigitalPost sikkerDigitalPost = sdpBuilder.buildDigitalPost(forsendelse);
-        StandardBusinessDocument standardBusinessDocument = StandardBusinessDocumentFactory.create(sbdhAvsender, sbdhMottaker, meldingsId, DateTime.now(),forsendelse.getKonversasjonsId(), sikkerDigitalPost);
+        StandardBusinessDocument standardBusinessDocument = StandardBusinessDocumentFactory.create(sbdhAvsender, sbdhMottaker, meldingsId, DateTime.now(), forsendelse.getKonversasjonsId(), sikkerDigitalPost);
 
         //Dokumentpakke
         Dokumentpakke dokumentpakke = createDokumentpakke.createDokumentpakke(databehandler, forsendelse);

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -10,8 +10,11 @@ import no.difi.begrep.sdp.schema_v10.SDPMottak;
 import no.difi.begrep.sdp.schema_v10.SDPReturpost;
 import no.difi.begrep.sdp.schema_v10.SDPVarslingfeilet;
 import no.difi.begrep.sdp.schema_v10.SDPVarslingskanal;
+import no.difi.sdp.client2.domain.AktørOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Avsender;
+import no.difi.sdp.client2.domain.AvsenderOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Databehandler;
+import no.difi.sdp.client2.domain.DatabehandlerOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -222,12 +225,13 @@ public class ObjectMother {
         return incomingReferences;
     }
 
-    public static Organisasjonsnummer avsenderOrganisasjonsnummer(){
-        return Organisasjonsnummer.of("988015814");
+    public static AvsenderOrganisasjonsnummer avsenderOrganisasjonsnummer() {
+
+        return AktørOrganisasjonsnummer.of("988015814").forfremTilAvsender();
     }
 
-    public static Organisasjonsnummer databehandlerOrganisasjonsnummer(){
-        return Organisasjonsnummer.of("984661185");
+    public static DatabehandlerOrganisasjonsnummer databehandlerOrganisasjonsnummer() {
+        return AktørOrganisasjonsnummer.of("984661185").forfremTilDatabehandler();
     }
 
     public static Forsendelse forsendelse(String mpcId, InputStream dokumentStream) {
@@ -251,8 +255,9 @@ public class ObjectMother {
                 .build();
     }
 
-    public static Databehandler databehandlerMedSertifikat(final Organisasjonsnummer organisasjonsnummer, final Noekkelpar noekkelpar) {
-        return Databehandler.builder(organisasjonsnummer, noekkelpar)
+    public static Databehandler databehandlerMedSertifikat(final String organisasjonsnummer, final Noekkelpar noekkelpar) {
+        return Databehandler
+                .builder(AktørOrganisasjonsnummer.of(organisasjonsnummer).forfremTilDatabehandler(), noekkelpar)
                 .build();
     }
 

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -254,7 +254,7 @@ public class ObjectMother {
                 .build();
     }
 
-    public static Databehandler databehandlerMedSertifikat(final String organisasjonsnummer, final Noekkelpar noekkelpar) {
+    public static Databehandler databehandlerMedSertifikat(final Organisasjonsnummer organisasjonsnummer, final Noekkelpar noekkelpar) {
         return Databehandler
                 .builder(AktørOrganisasjonsnummer.of(organisasjonsnummer).forfremTilDatabehandler(), noekkelpar)
                 .build();

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -226,7 +226,6 @@ public class ObjectMother {
     }
 
     public static AvsenderOrganisasjonsnummer avsenderOrganisasjonsnummer() {
-
         return AktørOrganisasjonsnummer.of("988015814").forfremTilAvsender();
     }
 

--- a/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
@@ -1,0 +1,28 @@
+package no.difi.sdp.client2.domain;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class AktørOrganisasjonsnummerTest {
+
+    @Test
+    public void forfrem_til_avsender(){
+        AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of("984661185");
+
+        AvsenderOrganisasjonsnummer avsenderOrganisasjonsnummer = organisasjonsnummer.forfremTilAvsender();
+
+        assertThat(avsenderOrganisasjonsnummer.getOrganisasjonsnummerMedLandkode(), equalTo(organisasjonsnummer.getOrganisasjonsnummerMedLandkode()));
+    }
+
+    @Test
+    public void forfrem_til_databehandler(){
+        AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of("984661185");
+
+        DatabehandlerOrganisasjonsnummer databehandlerOrganisasjonsnummer = organisasjonsnummer.forfremTilDatabehandler();
+
+        assertThat(databehandlerOrganisasjonsnummer.getOrganisasjonsnummerMedLandkode(), equalTo(organisasjonsnummer.getOrganisasjonsnummerMedLandkode()))   ;
+
+    }
+}

--- a/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertThat;
 public class AktørOrganisasjonsnummerTest {
 
     @Test
-    public void forfrem_til_avsender(){
+    public void forfrem_til_avsender() {
         AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of("984661185");
 
         AvsenderOrganisasjonsnummer avsenderOrganisasjonsnummer = organisasjonsnummer.forfremTilAvsender();
@@ -17,12 +17,11 @@ public class AktørOrganisasjonsnummerTest {
     }
 
     @Test
-    public void forfrem_til_databehandler(){
+    public void forfrem_til_databehandler() {
         AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of("984661185");
 
         DatabehandlerOrganisasjonsnummer databehandlerOrganisasjonsnummer = organisasjonsnummer.forfremTilDatabehandler();
 
-        assertThat(databehandlerOrganisasjonsnummer.getOrganisasjonsnummerMedLandkode(), equalTo(organisasjonsnummer.getOrganisasjonsnummerMedLandkode()))   ;
-
+        assertThat(databehandlerOrganisasjonsnummer.getOrganisasjonsnummerMedLandkode(), equalTo(organisasjonsnummer.getOrganisasjonsnummerMedLandkode()));
     }
 }

--- a/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/AktørOrganisasjonsnummerTest.java
@@ -1,11 +1,29 @@
 package no.difi.sdp.client2.domain;
 
+import no.digipost.api.representations.Organisasjonsnummer;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class AktørOrganisasjonsnummerTest {
+    @Test
+    public void create_organisasjonsnummer_from_string() {
+        String orgnr = "984661185";
+
+        AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of(orgnr);
+
+        assertThat(organisasjonsnummer.getOrganisasjonsnummer(), equalTo(orgnr));
+    }
+
+    @Test
+    public void create_organisasjonsnummer_from_class()  {
+        Organisasjonsnummer orgnr = Organisasjonsnummer.of("984661185");
+
+        AktørOrganisasjonsnummer organisasjonsnummer = AktørOrganisasjonsnummer.of(orgnr);
+
+        assertThat(organisasjonsnummer.getOrganisasjonsnummer(), equalTo(orgnr.getOrganisasjonsnummer()));
+    }
 
     @Test
     public void forfrem_til_avsender() {

--- a/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
+++ b/src/test/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilderTest.java
@@ -1,6 +1,7 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.sdp.client2.ObjectMother;
+import no.difi.sdp.client2.domain.AktørOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Databehandler;
 import no.difi.sdp.client2.domain.Dokument;
@@ -31,7 +32,7 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void bygg_minimalt_request() {
-        Databehandler databehandler = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler databehandler = Databehandler.builder(AktørOrganisasjonsnummer.of("991825827").forfremTilDatabehandler(), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
         Dokument dokument = Dokument.builder("Sensitiv tittel", "filnavn", new ByteArrayInputStream("hei".getBytes())).build();
@@ -49,7 +50,7 @@ public class EbmsForsendelseBuilderTest {
 
     @Test
     public void korrekt_mpc() {
-        Databehandler databehandler = Databehandler.builder(Organisasjonsnummer.of("991825827"), ObjectMother.noekkelpar()).build();
+        Databehandler databehandler = Databehandler.builder(AktørOrganisasjonsnummer.of("991825827").forfremTilDatabehandler(), ObjectMother.noekkelpar()).build();
         Mottaker mottaker = Mottaker.builder("01129955131", "postkasseadresse", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
         DigitalPost digitalpost = DigitalPost.builder(mottaker, "Ikke-sensitiv tittel").build();
 

--- a/src/test/java/no/difi/sdp/client2/internal/SDPBuilderManifestTest.java
+++ b/src/test/java/no/difi/sdp/client2/internal/SDPBuilderManifestTest.java
@@ -1,7 +1,9 @@
 package no.difi.sdp.client2.internal;
 
 import no.difi.begrep.sdp.schema_v10.SDPManifest;
+import no.difi.sdp.client2.domain.AktørOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Avsender;
+import no.difi.sdp.client2.domain.AvsenderOrganisasjonsnummer;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Dokumentpakke;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -45,7 +47,7 @@ public class SDPBuilderManifestTest {
     public void build_expected_manifest() throws Exception {
         String expectedXml = IOUtils.toString(this.getClass().getResourceAsStream("/asic/expected-asic-manifest.xml"), UTF_8);
 
-        Avsender avsender = Avsender.builder(Organisasjonsnummer.of("123456789")).fakturaReferanse("ØK1").avsenderIdentifikator("0123456789").build();
+        Avsender avsender = Avsender.builder(AktørOrganisasjonsnummer.of("123456789").forfremTilAvsender()).fakturaReferanse("ØK1").avsenderIdentifikator("0123456789").build();
 
         Mottaker mottaker = Mottaker.builder("11077941012", "123456", mottakerSertifikat(), Organisasjonsnummer.of("984661185")).build();
 

--- a/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
+++ b/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
@@ -10,6 +10,7 @@ import no.difi.sdp.client2.domain.Prioritet;
 import no.difi.sdp.client2.domain.kvittering.ForretningsKvittering;
 import no.difi.sdp.client2.domain.kvittering.KvitteringForespoersel;
 import no.difi.sdp.client2.domain.kvittering.LeveringsKvittering;
+import no.digipost.api.representations.Organisasjonsnummer;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -37,7 +38,7 @@ import static org.fest.assertions.api.Assertions.fail;
 public class SmokeTest {
 
     private static SikkerDigitalPostKlient sikkerDigitalPostKlient;
-    private static String organisasjonsnummerFraSertifikat;
+    private static Organisasjonsnummer organisasjonsnummerFraSertifikat;
     private static KeyStore keyStore;
 
     private static final String VIRKSOMHETSSERTIFIKAT_PASSWORD_ENVIRONMENT_VARIABLE = "virksomhetssertifikat_passord";
@@ -88,7 +89,7 @@ public class SmokeTest {
         return Noekkelpar.fraKeyStoreUtenTrustStore(keyStore, virksomhetssertifikatAliasValue, virksomhetssertifikatPasswordValue);
     }
 
-    private static String getOrganisasjonsnummerFraSertifikat() {
+    private static Organisasjonsnummer getOrganisasjonsnummerFraSertifikat() {
         try {
             X509Certificate cert = (X509Certificate) keyStore.getCertificate(virksomhetssertifikatAliasValue);
             if (cert == null) {
@@ -96,7 +97,7 @@ public class SmokeTest {
             }
             X500Name x500name = new JcaX509CertificateHolder(cert).getSubject();
             RDN serialnumber = x500name.getRDNs(BCStyle.SN)[0];
-            return IETFUtils.valueToString(serialnumber.getFirst().getValue());
+            return Organisasjonsnummer.of(IETFUtils.valueToString(serialnumber.getFirst().getValue()));
         } catch (CertificateEncodingException e) {
             throw new RuntimeException("Klarte ikke hente ut organisasjonsnummer fra sertifikatet.", e);
         } catch (KeyStoreException e) {

--- a/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
+++ b/src/test/java/no/difi/sdp/client2/smoke/SmokeTest.java
@@ -10,7 +10,6 @@ import no.difi.sdp.client2.domain.Prioritet;
 import no.difi.sdp.client2.domain.kvittering.ForretningsKvittering;
 import no.difi.sdp.client2.domain.kvittering.KvitteringForespoersel;
 import no.difi.sdp.client2.domain.kvittering.LeveringsKvittering;
-import no.digipost.api.representations.Organisasjonsnummer;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -38,7 +37,7 @@ import static org.fest.assertions.api.Assertions.fail;
 public class SmokeTest {
 
     private static SikkerDigitalPostKlient sikkerDigitalPostKlient;
-    private static Organisasjonsnummer organisasjonsnummerFraSertifikat;
+    private static String organisasjonsnummerFraSertifikat;
     private static KeyStore keyStore;
 
     private static final String VIRKSOMHETSSERTIFIKAT_PASSWORD_ENVIRONMENT_VARIABLE = "virksomhetssertifikat_passord";
@@ -89,7 +88,7 @@ public class SmokeTest {
         return Noekkelpar.fraKeyStoreUtenTrustStore(keyStore, virksomhetssertifikatAliasValue, virksomhetssertifikatPasswordValue);
     }
 
-    private static Organisasjonsnummer getOrganisasjonsnummerFraSertifikat() {
+    private static String getOrganisasjonsnummerFraSertifikat() {
         try {
             X509Certificate cert = (X509Certificate) keyStore.getCertificate(virksomhetssertifikatAliasValue);
             if (cert == null) {
@@ -97,7 +96,7 @@ public class SmokeTest {
             }
             X500Name x500name = new JcaX509CertificateHolder(cert).getSubject();
             RDN serialnumber = x500name.getRDNs(BCStyle.SN)[0];
-            return Organisasjonsnummer.of(IETFUtils.valueToString(serialnumber.getFirst().getValue()));
+            return IETFUtils.valueToString(serialnumber.getFirst().getValue());
         } catch (CertificateEncodingException e) {
             throw new RuntimeException("Klarte ikke hente ut organisasjonsnummer fra sertifikatet.", e);
         } catch (KeyStoreException e) {


### PR DESCRIPTION
- AvsenderOrganisasjonsnummer og DatabehandlerOrganisasjonsnummer for å tvinge avsendere til å ta stilling til hvilken type orgnummer det er.
- Lagt til Hamcrest for bruk i tester