### PR TITLE
Legger til håndtering av bygg ved PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,7 @@ before_install:
 install: true
 
 script:
-  - mvn clean deploy --update-snapshots -PunitTests --settings ~/.m2/deploy-settings.xml
+  - 'echo "TRAVIS_PULL_REQUEST value: $TRAVIS_PULL_REQUEST"'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --update-snapshots -PunitTests --settings ~/.m2/deploy-settings.xml; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean install --update-snapshots -PunitTests; fi' #Uses !="false" because $TRAVIS_PULL_REQUEST is the Pull Request # if such is the case.
+


### PR DESCRIPTION
Ved draforespørsler fra andre repoer så vil ikke secretene til Travis lastes og da kan ikke pakken pushes til Sonatype. Med denne endringen vil vi  kun gjøre en `clean install` for å se at testene kjører for PR. Gjør ca som vist i https://docs.travis-ci.com/user/pull-requests/, men har scriptene inline i travis.yml. Logikken for å sjekke at noe ikke er false er litt underlig, men det er det lagt inn kommentar på, for det er litt stress å debugge.

Hvordan kan man sjekke at dette fungerer? Metameta: hvis Travis kjører fint her så vet vi at det fungerer for PR. Har testet for vanlige, og det flyr fint det også.