### PR TITLE
Oppdaterer UserAgent med nytt format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
@@ -423,7 +424,7 @@
                                         <include>org.bouncycastle:bcprov-jdk15on:1.50</include>
                                         <include>org.codehaus.woodstox:stax2-api:3.1.4</include>
                                         <include>org.codehaus.woodstox:woodstox-core-asl:4.3.0</include>
-                                        <include>org.hamcrest:hamcrest-core:${hamcrest-version}</include>
+                                        <include>org.hamcrest:hamcrest-core</include>
                                         <include>org.jasypt:jasypt:1.9.1</include>
                                         <include>org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.6.5.1</include>
                                         <include>org.opensaml:*</include>
@@ -458,6 +459,17 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/projectversion</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
     </build>
 
 

--- a/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
+++ b/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
@@ -18,9 +18,8 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
     private final String javaVersion;
 
     public AddClientVersionInterceptor() {
-        String implementationVersion = getProjectVersion();
+        this.clientVersion = getProjectVersion();
         String javaVersion = System.getProperty("java.version");
-        this.clientVersion = implementationVersion != null ? implementationVersion : System.getProperty("user.name");
         this.javaVersion = javaVersion != null ? javaVersion : "UNKNOWN";
     }
 

--- a/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
+++ b/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
+import java.text.MessageFormat;
 
 public class AddClientVersionInterceptor implements HttpRequestInterceptor {
 
@@ -16,20 +17,19 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
     public AddClientVersionInterceptor() {
         String implementationVersion = getClass().getPackage().getImplementationVersion();
         String javaVersion = System.getProperty("java.version");
-        this.clientVersion = implementationVersion != null ? implementationVersion : "UNKNOWN";
+        this.clientVersion = implementationVersion != null ? implementationVersion : System.getProperty("user.name");
         this.javaVersion = javaVersion != null ? javaVersion : "UNKNOWN";
     }
 
     @Override
     public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
         Header[] headers = request.getHeaders("User-Agent");
-        String clientUserAgent = "Java/" + javaVersion + " DifiSdp/" + clientVersion;
+        String clientUserAgent = MessageFormat.format("difi-sikker-digital-post-klient-java/{0} (Java/{1})", clientVersion, javaVersion);
+
         if (headers.length == 0) {
             request.addHeader("User-Agent", clientUserAgent);
-        }
-        else {
+        } else {
             request.addHeader("User-Agent", headers[0].getValue() + " " + clientUserAgent);
         }
     }
-
 }

--- a/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
+++ b/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
@@ -14,7 +14,16 @@ import java.util.Properties;
 
 public class AddClientVersionInterceptor implements HttpRequestInterceptor {
 
-    private static final String clientVersion = getProjectVersion();
+    private static final String CLIENT_VERSION; static {
+        try (InputStream resourceAsStream = AddClientVersionInterceptor.class.getResourceAsStream("/project.properties")) {
+            Properties properties = new Properties();
+            properties.load(resourceAsStream);
+            CLIENT_VERSION = properties.getProperty("version");
+        } catch (IOException e) {
+            throw new SendIOException(e);
+        }
+    }
+
     private final String javaVersion;
 
     public AddClientVersionInterceptor() {
@@ -25,22 +34,12 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
     @Override
     public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
         Header[] headers = request.getHeaders("User-Agent");
-        String clientUserAgent = MessageFormat.format("difi-sikker-digital-post-klient-java/{0} (Java/{1})", clientVersion, javaVersion);
+        String clientUserAgent = MessageFormat.format("difi-sikker-digital-post-klient-java/{0} (Java/{1})", CLIENT_VERSION, javaVersion);
 
         if (headers.length == 0) {
             request.addHeader("User-Agent", clientUserAgent);
         } else {
             request.addHeader("User-Agent", headers[0].getValue() + " " + clientUserAgent);
-        }
-    }
-
-    private static String getProjectVersion() {
-        try (InputStream resourceAsStream = AddClientVersionInterceptor.class.getResourceAsStream("/project.properties")) {
-            Properties properties = new Properties();
-            properties.load(resourceAsStream);
-            return properties.getProperty("version");
-        } catch (IOException e) {
-            throw new SendIOException(e);
         }
     }
 }

--- a/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
+++ b/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
@@ -1,5 +1,6 @@
 package no.difi.sdp.client2.internal;
 
+import no.difi.sdp.client2.domain.exceptions.SendIOException;
 import org.apache.http.Header;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -7,7 +8,9 @@ import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.Properties;
 
 public class AddClientVersionInterceptor implements HttpRequestInterceptor {
 
@@ -15,7 +18,7 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
     private final String javaVersion;
 
     public AddClientVersionInterceptor() {
-        String implementationVersion = getClass().getPackage().getImplementationVersion();
+        String implementationVersion = getProjectVersion();
         String javaVersion = System.getProperty("java.version");
         this.clientVersion = implementationVersion != null ? implementationVersion : System.getProperty("user.name");
         this.javaVersion = javaVersion != null ? javaVersion : "UNKNOWN";
@@ -31,5 +34,18 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
         } else {
             request.addHeader("User-Agent", headers[0].getValue() + " " + clientUserAgent);
         }
+    }
+
+    private String getProjectVersion() {
+        InputStream resourceAsStream = this.getClass().getResourceAsStream("/project.properties");
+        Properties properties = new Properties();
+
+        try {
+           properties.load(resourceAsStream);
+        } catch (IOException e) {
+            throw new SendIOException(e);
+        }
+
+        return properties.getProperty("version");
     }
 }

--- a/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
+++ b/src/main/java/no/difi/sdp/client2/internal/AddClientVersionInterceptor.java
@@ -14,11 +14,10 @@ import java.util.Properties;
 
 public class AddClientVersionInterceptor implements HttpRequestInterceptor {
 
-    private final String clientVersion;
+    private static final String clientVersion = getProjectVersion();
     private final String javaVersion;
 
     public AddClientVersionInterceptor() {
-        this.clientVersion = getProjectVersion();
         String javaVersion = System.getProperty("java.version");
         this.javaVersion = javaVersion != null ? javaVersion : "UNKNOWN";
     }
@@ -35,16 +34,13 @@ public class AddClientVersionInterceptor implements HttpRequestInterceptor {
         }
     }
 
-    private String getProjectVersion() {
-        InputStream resourceAsStream = this.getClass().getResourceAsStream("/project.properties");
-        Properties properties = new Properties();
-
-        try {
-           properties.load(resourceAsStream);
+    private static String getProjectVersion() {
+        try (InputStream resourceAsStream = AddClientVersionInterceptor.class.getResourceAsStream("/project.properties")) {
+            Properties properties = new Properties();
+            properties.load(resourceAsStream);
+            return properties.getProperty("version");
         } catch (IOException e) {
             throw new SendIOException(e);
         }
-
-        return properties.getProperty("version");
     }
 }

--- a/src/main/projectversion/project.properties
+++ b/src/main/projectversion/project.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
Nå har vi user agent på et litt mer verbost format enn tidligere. Navnet er nå det samme som selve klienten og er også samme som for .NET. Likt er fint! Det er et dypere rasjonale for dette formatet i form av en fyldig guide på internettet, men den finner jeg ikke igjen. Her er det bare å ta dette for god 🐟.