### PR TITLE
Dependency cleanups

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,7 +33,7 @@ This software includes third party software subject to the following licenses:
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
   JavaMail 1.4 under The Apache Software License, Version 2.0
-  JavaMail API (no providers) under CDDL/GPLv2+CE
+  JavaMail API under CDDL/GPLv2+CE
   javax.xml.soap API under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   jaxen under The BSD 3-Clause License
@@ -80,7 +80,5 @@ This software includes third party software subject to the following licenses:
   Spring XML under The Apache Software License, Version 2.0
   spring-security-core under The Apache Software License, Version 2.0
   Stax2 API under The BSD License
-  Streaming API for XML under GNU General Public Library or COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
-  Sun Java Streaming XML Parser under CDDL-1.0 or GPL-2.0
   Woodstox under The Apache Software License, Version 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>1.2.1</sdp-shared.version>
+        <sdp-shared.version>1.2.2</sdp-shared.version>
 
         <spring.version>4.3.2.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>
@@ -206,6 +206,12 @@
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
             <version>2.0.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.stream</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <prerequisites>
@@ -34,7 +33,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.1</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -483,7 +482,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>HEAD</tag>
+        <tag>5.0.1</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.0.1</version>
+    <version>5.0.2-SNAPSHOT</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -482,7 +482,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>5.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>


### PR DESCRIPTION
- Exclude transitive dependency `stax-api`. Prefer JDK builtins instead.
- Upgrade SDP-shared. New version has some similar dependency cleanups: https://github.com/digipost/sdp-shared/releases/tag/1.2.2