### PR TITLE
Erstatte Joda Time med Java Time API (oppdating av SDP Shared til v2.0)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,6 +24,7 @@ This software includes third party software subject to the following licenses:
   Byte Buddy Java agent under The Apache Software License, Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
   Digipost Certificate Validator under The Apache Software License, Version 2.0
+  Digipost Digg under The Apache Software License, Version 2.0
   ehcache under The Apache Software License, Version 2.0
   Extended StAX API under Dual license consisting of the CDDL v1.1 and GPL v2
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -36,7 +36,7 @@ This software includes third party software subject to the following licenses:
   javax.xml.soap API under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   jaxen under The BSD 3-Clause License
-  JCL 1.1.1 implemented over SLF4J under MIT License
+  JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
   JUL to SLF4J bridge under MIT License
   JUnit under Eclipse Public License 1.0
@@ -44,7 +44,7 @@ This software includes third party software subject to the following licenses:
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   MIME streaming extension under CDDL 1.1 or GPL2 w/ CPE
-  Mockito under The MIT License
+  mockito-core under The MIT License
   Objenesis under Apache 2
   OpenSAML :: Core under The Apache Software License, Version 2.0
   OpenSAML :: Profile API under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.1.2-SNAPSHOT</version>
+    <version>5.2-SNAPSHOT</version>
     <name>Sikker digital post-klient</name>
 
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <sdp-shared.version>1.2.2</sdp-shared.version>
 
-        <spring.version>4.3.2.RELEASE</spring.version>
+        <spring.version>4.3.7.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>
         <spring.security.version>4.1.0.RELEASE</spring.security.version>
     </properties>
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.5</version>
         </dependency>
 
         <dependency>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <version>4.4.6</version>
         </dependency>
 
         <dependency>
@@ -124,12 +124,10 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-oxm</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -196,13 +194,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.26</version>
+            <version>2.7.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.xml.stream</groupId>
@@ -213,18 +211,18 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.24</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.24</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -244,7 +242,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -287,7 +285,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0.rc1</version>
+                    <version>3.0</version>
                     <configuration>
                         <header>src/main/resources/header.txt</header>
                         <strictCheck>true</strictCheck>
@@ -310,7 +308,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.8.0</version>
+                    <version>0.9.4</version>
                     <configuration>
                         <newVersion>
                             <file>
@@ -339,7 +337,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>2.0-SNAPSHOT</sdp-shared.version>
+        <sdp-shared.version>2.0</sdp-shared.version>
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>1.2.2</sdp-shared.version>
+        <sdp-shared.version>2.0-SNAPSHOT</sdp-shared.version>
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>
@@ -168,12 +168,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.6</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -196,6 +190,12 @@
             <artifactId>mockito-core</artifactId>
             <version>2.7.13</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.digipost</groupId>
+            <artifactId>digg</artifactId>
+            <scope>test</scope>
+            <version>0.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>

--- a/src/main/java/no/difi/sdp/client2/KlientKonfigurasjon.java
+++ b/src/main/java/no/difi/sdp/client2/KlientKonfigurasjon.java
@@ -14,8 +14,24 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class KlientKonfigurasjon {
 
+    public static Builder builder(Miljo miljo) {
+        return new Builder(miljo);
+    }
+
+    @Deprecated
+    public static Builder builder(String meldingsformidlerRootUri) {
+        return builder(URI.create(meldingsformidlerRootUri));
+    }
+
+    @Deprecated
+    public static Builder builder(URI meldingsformidlerRoot) {
+        return builder(new Miljo(null, meldingsformidlerRoot));
+    }
+
+
     private final Organisasjonsnummer meldingsformidlerOrganisasjon = Organisasjonsnummer.of("984661185");
 
+    private final Miljo miljo;
     private String proxyHost;
     private int proxyPort;
     private String proxyScheme = "https";
@@ -26,20 +42,11 @@ public class KlientKonfigurasjon {
     private ClientInterceptor[] soapInterceptors = new ClientInterceptor[0];
     private HttpRequestInterceptor[] httpRequestInterceptors = new HttpRequestInterceptor[0];
     private HttpResponseInterceptor[] httpResponseInterceptors = new HttpResponseInterceptor[0];
-    private Miljo miljo;
 
-    @Deprecated
-    private KlientKonfigurasjon(URI meldingsformidlerRoot) {
-        miljo = new Miljo(null,meldingsformidlerRoot);
-    }
+
 
     private KlientKonfigurasjon(Miljo miljo) {
         this.miljo = miljo;
-    }
-
-    @Deprecated
-    public static Builder builder(URI meldingsformidlerRoot) {
-        return new Builder(meldingsformidlerRoot);
     }
 
     public String getProxyHost() {
@@ -90,78 +97,67 @@ public class KlientKonfigurasjon {
         return httpResponseInterceptors;
     }
 
-    public Miljo getMiljo() { return miljo; }
-
-    @Deprecated
-    public static Builder builder(String meldingsformidlerRootUri) {
-        return builder(URI.create(meldingsformidlerRootUri));
-    }
-
-    public static Builder builder(Miljo miljo) {
-        return new Builder(miljo);
+    public Miljo getMiljo() {
+        return miljo;
     }
 
     public EbmsEndpointUriBuilder getMeldingsformidlerRoot() {
         return EbmsEndpointUriBuilder.meldingsformidlerUri(miljo.getMeldingsformidlerRoot());
     }
 
+
     public static class Builder {
 
         private final KlientKonfigurasjon target;
-
-        @Deprecated
-        private Builder(URI meldingsformidlerRoot) {
-            target = new KlientKonfigurasjon(meldingsformidlerRoot);
-        }
 
         private Builder(Miljo miljo){
             target = new KlientKonfigurasjon(miljo);
         }
 
-        public Builder proxy(final String proxyHost, final int proxyPort) {
+        public Builder proxy(String proxyHost, int proxyPort) {
             target.proxyHost = proxyHost;
             target.proxyPort = proxyPort;
             return this;
         }
 
-        public Builder proxy(final String proxyHost, final int proxyPort, final String proxyScheme) {
+        public Builder proxy(String proxyHost, int proxyPort, String proxyScheme) {
             target.proxyHost = proxyHost;
             target.proxyPort = proxyPort;
             target.proxyScheme = proxyScheme;
             return this;
         }
 
-        public Builder socketTimeout(final int socketTimeout, final TimeUnit timeUnit) {
+        public Builder socketTimeout(int socketTimeout, TimeUnit timeUnit) {
             target.socketTimeoutInMillis = timeUnit.toMillis(socketTimeout);
             return this;
         }
 
-        public Builder connectionTimeout(final int connectionTimeout, final TimeUnit timeUnit) {
+        public Builder connectionTimeout(int connectionTimeout, TimeUnit timeUnit) {
             target.connectTimeoutInMillis = timeUnit.toMillis(connectionTimeout);
             return this;
         }
 
-        public Builder connectionRequestTimeout(final int connectionRequestTimeout, final TimeUnit timeUnit) {
+        public Builder connectionRequestTimeout(int connectionRequestTimeout, TimeUnit timeUnit) {
             target.connectionRequestTimeoutInMillis = timeUnit.toMillis(connectionRequestTimeout);
             return this;
         }
 
-        public Builder maxConnectionPoolSize(final int maxConnectionPoolSize) {
+        public Builder maxConnectionPoolSize(int maxConnectionPoolSize) {
             target.maxConnectionPoolSize = maxConnectionPoolSize;
             return this;
         }
 
-        public Builder soapInterceptors(final ClientInterceptor... soapInterceptors) {
+        public Builder soapInterceptors(ClientInterceptor... soapInterceptors) {
             target.soapInterceptors = soapInterceptors;
             return this;
         }
 
-        public Builder httpRequestInterceptors(final HttpRequestInterceptor... httpRequestInterceptors) {
+        public Builder httpRequestInterceptors(HttpRequestInterceptor... httpRequestInterceptors) {
             target.httpRequestInterceptors = httpRequestInterceptors;
             return this;
         }
 
-        public Builder httpResponseInterceptors(final HttpResponseInterceptor... httpResponseInterceptors) {
+        public Builder httpResponseInterceptors(HttpResponseInterceptor... httpResponseInterceptors) {
             target.httpResponseInterceptors = httpResponseInterceptors;
             return this;
         }

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 
 import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.KLIENT;
 import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.SERVER;
-import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.UKJENT;
 
 public class DigipostMessageSenderFacade {
 

--- a/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/EbmsForsendelseBuilder.java
@@ -9,9 +9,9 @@ import no.digipost.api.representations.EbmsAktoer;
 import no.digipost.api.representations.EbmsForsendelse;
 import no.digipost.api.representations.Organisasjonsnummer;
 import no.digipost.api.representations.StandardBusinessDocumentFactory;
-import org.joda.time.DateTime;
 import org.unece.cefact.namespaces.standardbusinessdocumentheader.StandardBusinessDocument;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 public class EbmsForsendelseBuilder {
@@ -35,7 +35,7 @@ public class EbmsForsendelseBuilder {
         Organisasjonsnummer sbdhMottaker = mottaker.organisasjonsnummer;
         Organisasjonsnummer sbdhAvsender = Organisasjonsnummer.of(databehandler.organisasjonsnummer.getOrganisasjonsnummer());
         SDPDigitalPost sikkerDigitalPost = sdpBuilder.buildDigitalPost(forsendelse);
-        StandardBusinessDocument standardBusinessDocument = StandardBusinessDocumentFactory.create(sbdhAvsender, sbdhMottaker, meldingsId, DateTime.now(), forsendelse.getKonversasjonsId(), sikkerDigitalPost);
+        StandardBusinessDocument standardBusinessDocument = StandardBusinessDocumentFactory.create(sbdhAvsender, sbdhMottaker, meldingsId, ZonedDateTime.now(), forsendelse.getKonversasjonsId(), sikkerDigitalPost);
 
         Billable<Dokumentpakke> dokumentpakkeWithBillableBytes = createDokumentpakke.createDokumentpakke(databehandler, forsendelse);
 

--- a/src/main/java/no/difi/sdp/client2/internal/KvitteringBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/KvitteringBuilder.java
@@ -20,8 +20,6 @@ import no.digipost.api.representations.EbmsPullRequest;
 import no.digipost.api.representations.Organisasjonsnummer;
 import no.digipost.api.representations.SimpleStandardBusinessDocument;
 
-import java.time.Instant;
-
 import static no.digipost.api.representations.EbmsAktoer.meldingsformidler;
 
 public class KvitteringBuilder {
@@ -39,7 +37,7 @@ public class KvitteringBuilder {
 
         if (simpleStandardBusinessDocument.erKvittering()) {
             SDPKvittering sdpKvittering = simpleStandardBusinessDocument.getKvittering().kvittering;
-            kvitteringsinfoBuilder.tidspunkt(Instant.ofEpochMilli(sdpKvittering.getTidspunkt().getMillis()));
+            kvitteringsinfoBuilder.tidspunkt(sdpKvittering.getTidspunkt().toInstant());
 
             final KvitteringsInfo kvitteringsInfo = kvitteringsinfoBuilder.build();
 
@@ -56,7 +54,7 @@ public class KvitteringBuilder {
             }
         } else if (simpleStandardBusinessDocument.erFeil()) {
             SDPFeil sdpFeil = simpleStandardBusinessDocument.getFeil();
-            kvitteringsinfoBuilder.tidspunkt(Instant.ofEpochMilli(sdpFeil.getTidspunkt().getMillis()));
+            kvitteringsinfoBuilder.tidspunkt(sdpFeil.getTidspunkt().toInstant());
 
             final KvitteringsInfo kvitteringsInfo = kvitteringsinfoBuilder.build();
 

--- a/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
@@ -1,6 +1,27 @@
 package no.difi.sdp.client2.internal;
 
-import no.difi.begrep.sdp.schema_v10.*;
+import no.difi.begrep.sdp.schema_v10.SDPAvsender;
+import no.difi.begrep.sdp.schema_v10.SDPDigitalPost;
+import no.difi.begrep.sdp.schema_v10.SDPDigitalPostInfo;
+import no.difi.begrep.sdp.schema_v10.SDPDokument;
+import no.difi.begrep.sdp.schema_v10.SDPEpostVarsel;
+import no.difi.begrep.sdp.schema_v10.SDPEpostVarselTekst;
+import no.difi.begrep.sdp.schema_v10.SDPFysiskPostInfo;
+import no.difi.begrep.sdp.schema_v10.SDPFysiskPostRetur;
+import no.difi.begrep.sdp.schema_v10.SDPFysiskPostadresse;
+import no.difi.begrep.sdp.schema_v10.SDPIso6523Authority;
+import no.difi.begrep.sdp.schema_v10.SDPManifest;
+import no.difi.begrep.sdp.schema_v10.SDPMottaker;
+import no.difi.begrep.sdp.schema_v10.SDPNorskPostadresse;
+import no.difi.begrep.sdp.schema_v10.SDPOrganisasjon;
+import no.difi.begrep.sdp.schema_v10.SDPPerson;
+import no.difi.begrep.sdp.schema_v10.SDPRepetisjoner;
+import no.difi.begrep.sdp.schema_v10.SDPSikkerhetsnivaa;
+import no.difi.begrep.sdp.schema_v10.SDPSmsVarsel;
+import no.difi.begrep.sdp.schema_v10.SDPSmsVarselTekst;
+import no.difi.begrep.sdp.schema_v10.SDPTittel;
+import no.difi.begrep.sdp.schema_v10.SDPUtenlandskPostadresse;
+import no.difi.begrep.sdp.schema_v10.SDPVarsler;
 import no.difi.sdp.client2.domain.Avsender;
 import no.difi.sdp.client2.domain.Dokument;
 import no.difi.sdp.client2.domain.Forsendelse;
@@ -10,16 +31,17 @@ import no.difi.sdp.client2.domain.digital_post.SmsVarsel;
 import no.difi.sdp.client2.domain.fysisk_post.FysiskPost;
 import no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse;
 import no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse.Type;
-import org.joda.time.DateTime;
 import org.w3.xmldsig.Reference;
 import org.w3.xmldsig.Signature;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import static no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse.Type.NORSK;
 import static no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse.Type.UTENLANDSK;
+import static no.difi.sdp.client2.internal.SdpTimeConstants.UTC;
 
 @SuppressWarnings("ConstantConditions")
 public class SDPBuilder {
@@ -88,9 +110,9 @@ public class SDPBuilder {
         	return null;
         }
 
-        DateTime virkningstidspunkt = null;
+        ZonedDateTime virkningstidspunkt = null;
         if (digitalPost.getVirkningsdato() != null) {
-            virkningstidspunkt = new DateTime(digitalPost.getVirkningsdato().getTime());
+            virkningstidspunkt = ZonedDateTime.ofInstant(digitalPost.getVirkningsdato().toInstant(), UTC);
         }
 
         boolean aapningskvittering = digitalPost.isAapningskvittering();

--- a/src/main/java/no/difi/sdp/client2/internal/SdpTimeConstants.java
+++ b/src/main/java/no/difi/sdp/client2/internal/SdpTimeConstants.java
@@ -1,0 +1,9 @@
+package no.difi.sdp.client2.internal;
+
+import java.time.ZoneId;
+
+public class SdpTimeConstants {
+
+    public static final ZoneId UTC = ZoneId.of("UTC");
+
+}

--- a/src/main/java/no/difi/sdp/client2/internal/Wss4jClientSecurityExceptionMapper.java
+++ b/src/main/java/no/difi/sdp/client2/internal/Wss4jClientSecurityExceptionMapper.java
@@ -3,14 +3,13 @@ package no.difi.sdp.client2.internal;
 import no.difi.sdp.client2.domain.Noekkelpar;
 import no.difi.sdp.client2.domain.exceptions.NoekkelException;
 import no.difi.sdp.client2.domain.exceptions.SendException;
-import no.difi.sdp.client2.domain.exceptions.SikkerDigitalPostException;
 import no.difi.sdp.client2.domain.exceptions.UgyldigTidsstempelException;
 import no.digipost.api.exceptions.MessageSenderEbmsErrorException;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.server.EndpointExceptionResolver;
 import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityValidationException;
 
-import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.*;
+import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.UKJENT;
 
 /**
  * Even if this class implements the {@see org.springframework.ws.server.EndpointExceptionResolver}, this implementation is injected into our {@see no.digipost.api.interceptors.WsSecurityInterceptor},

--- a/src/test/java/no/difi/sdp/client2/KlientKonfigurasjonTest.java
+++ b/src/test/java/no/difi/sdp/client2/KlientKonfigurasjonTest.java
@@ -5,8 +5,7 @@ import org.junit.Test;
 
 import java.net.URI;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class KlientKonfigurasjonTest {
@@ -15,12 +14,11 @@ public class KlientKonfigurasjonTest {
     public void uri_builder_initializes_meldingsformidler_root_and_miljo() {
         URI meldingsformidlerRoot = URI.create("http://meldingsformidlerroot.no");
 
-        KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon
-                .builder(meldingsformidlerRoot)
-                .build();
+        @SuppressWarnings("deprecation")
+        KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon.builder(meldingsformidlerRoot).build();
 
-        assertThat(klientKonfigurasjon.getMeldingsformidlerRoot().getBaseUri(), equalTo(meldingsformidlerRoot));
-        assertThat(klientKonfigurasjon.getMiljo().getMeldingsformidlerRoot(), equalTo(meldingsformidlerRoot));
+        assertThat(klientKonfigurasjon.getMeldingsformidlerRoot().getBaseUri(), is(meldingsformidlerRoot));
+        assertThat(klientKonfigurasjon.getMiljo().getMeldingsformidlerRoot(), is(meldingsformidlerRoot));
     }
 
     @Test
@@ -32,8 +30,8 @@ public class KlientKonfigurasjonTest {
 
         Miljo actualMiljo = klientKonfigurasjon.getMiljo();
 
-        assertThat(actualMiljo, equalTo(funksjoneltTestmiljo));
-        assertEquals(klientKonfigurasjon.getMeldingsformidlerRoot().getBaseUri(), actualMiljo.getMeldingsformidlerRoot());
+        assertThat(actualMiljo, is(funksjoneltTestmiljo));
+        assertThat(actualMiljo.getMeldingsformidlerRoot(), is(klientKonfigurasjon.getMeldingsformidlerRoot().getBaseUri()));
     }
 
 }

--- a/src/test/java/no/difi/sdp/client2/ObjectMother.java
+++ b/src/test/java/no/difi/sdp/client2/ObjectMother.java
@@ -33,7 +33,6 @@ import no.digipost.api.representations.EbmsApplikasjonsKvittering;
 import no.digipost.api.representations.Organisasjonsnummer;
 import no.digipost.api.representations.StandardBusinessDocumentFactory;
 import no.digipost.security.DigipostSecurity;
-import org.joda.time.DateTime;
 import org.springframework.core.io.ClassPathResource;
 import org.unece.cefact.namespaces.standardbusinessdocumentheader.BusinessScope;
 import org.unece.cefact.namespaces.standardbusinessdocumentheader.DocumentIdentification;
@@ -53,6 +52,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -213,7 +213,7 @@ public class ObjectMother {
     }
 
     public static EbmsApplikasjonsKvittering createEbmsFeil(final SDPFeiltype feiltype) {
-        SDPFeil sdpFeil = new SDPFeil(null, DateTime.now(), feiltype, "Feilinformasjon");
+        SDPFeil sdpFeil = new SDPFeil(null, ZonedDateTime.now(), feiltype, "Feilinformasjon");
         return createEbmsKvittering(sdpFeil);
     }
 
@@ -231,7 +231,7 @@ public class ObjectMother {
                                 .withTypeVersion("1.0")
                                 .withInstanceIdentifier("instanceIdentifier")
                                 .withType(StandardBusinessDocumentFactory.Type.from((SDPMelding) sdpMelding).toString())
-                                .withCreationDateAndTime(DateTime.now())
+                                .withCreationDateAndTime(ZonedDateTime.now())
                         )
                         .withBusinessScope(new BusinessScope()
                                 .withScopes(new Scope()
@@ -274,29 +274,29 @@ public class ObjectMother {
     }
 
     public static EbmsApplikasjonsKvittering createEbmsAapningsKvittering() {
-        SDPKvittering aapningsKvittering = new SDPKvittering(null, DateTime.now(), null, null, new SDPAapning(), null, null);
+        SDPKvittering aapningsKvittering = new SDPKvittering(null, ZonedDateTime.now(), null, null, new SDPAapning(), null, null);
         return createEbmsKvittering(aapningsKvittering);
     }
 
     public static EbmsApplikasjonsKvittering createEbmsLeveringsKvittering() {
-        SDPKvittering leveringsKvittering = new SDPKvittering(null, DateTime.now(), null, null, null, new SDPLevering(), null);
+        SDPKvittering leveringsKvittering = new SDPKvittering(null, ZonedDateTime.now(), null, null, null, new SDPLevering(), null);
 
         return createEbmsKvittering(leveringsKvittering);
     }
 
     public static EbmsApplikasjonsKvittering createEbmsMottaksKvittering() {
-        SDPKvittering mottaksKvittering = new SDPKvittering(null, DateTime.now(), null, null, null, null, new SDPMottak());
+        SDPKvittering mottaksKvittering = new SDPKvittering(null, ZonedDateTime.now(), null, null, null, null, new SDPMottak());
         return createEbmsKvittering(mottaksKvittering);
     }
 
     public static EbmsApplikasjonsKvittering createEbmsReturpostKvittering() {
-        SDPKvittering returpostKvittering = new SDPKvittering(null, DateTime.now(), new SDPReturpost(), null, null, null, null);
+        SDPKvittering returpostKvittering = new SDPKvittering(null, ZonedDateTime.now(), new SDPReturpost(), null, null, null, null);
         return createEbmsKvittering(returpostKvittering);
     }
 
     public static EbmsApplikasjonsKvittering createEbmsVarslingFeiletKvittering(final SDPVarslingskanal varslingskanal) {
         SDPVarslingfeilet sdpVarslingfeilet = new SDPVarslingfeilet(varslingskanal, "Varsling feilet 'Viktig brev'");
-        SDPKvittering varslingFeiletKvittering = new SDPKvittering(null, DateTime.now(), null, sdpVarslingfeilet, null, null, null);
+        SDPKvittering varslingFeiletKvittering = new SDPKvittering(null, ZonedDateTime.now(), null, sdpVarslingfeilet, null, null, null);
         return createEbmsKvittering(varslingFeiletKvittering);
     }
 

--- a/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
+++ b/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import static no.difi.sdp.client2.ObjectMother.databehandler;
@@ -19,12 +20,14 @@ import static org.junit.Assert.fail;
 
 public class SikkerDigitalPostKlientTest {
 
+    private static final URI lokalTimeoutUrl = URI.create("http://10.255.255.1");
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void handles_connection_timeouts() {
-        String lokalTimeoutUrl = "http://10.255.255.1";
+        @SuppressWarnings("deprecation")
         KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon.builder(lokalTimeoutUrl)
                 .connectionTimeout(1, TimeUnit.MILLISECONDS)
                 .build();
@@ -41,9 +44,9 @@ public class SikkerDigitalPostKlientTest {
 
     @Test
     public void calls_http_interceptors() {
-        final StringBuffer interceptorString = new StringBuffer();
+        final StringBuilder interceptorString = new StringBuilder();
 
-        String lokalTimeoutUrl = "http://10.255.255.1";
+        @SuppressWarnings("deprecation")
         KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon.builder(lokalTimeoutUrl)
                 .connectionTimeout(1, TimeUnit.MILLISECONDS)
                 .httpRequestInterceptors(
@@ -63,9 +66,11 @@ public class SikkerDigitalPostKlientTest {
 
     @Test
     public void calls_certificate_validator_on_init() {
-        thrown.expect(SertifikatException.class);
         Databehandler databehandlerWithTestCertificate = databehandler();
-        new SikkerDigitalPostKlient(databehandlerWithTestCertificate, KlientKonfigurasjon.builder(Miljo.PRODUKSJON).build());
+        KlientKonfigurasjon konfigurasjon = KlientKonfigurasjon.builder(Miljo.PRODUKSJON).build();
+
+        thrown.expect(SertifikatException.class);
+        new SikkerDigitalPostKlient(databehandlerWithTestCertificate, konfigurasjon);
     }
 
 }


### PR DESCRIPTION
[sdp-shared](https://github.com/digipost/sdp-shared/)-biblioteket har fått en oppdatering hvor vi har erstattet all bruk av Joda Time med [Java Time API](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html). I forbindelse med det har jeg også oppdatert klientbiblioteket. Det var kun snakk om interne endringer, og public API i biblioteket har ikke blitt endret som sådan. Har derfor valgt å inkrementere minor version.

I tillegg gjort en lite generelt "løft" på avhengigheter, Maven-plugins, samt noe mindre koderydding.

