### PR TITLE
Eksponerer WebServiceTemplate fra klientbiblioteket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.5-SNAPSHOT</version>
+    <version>5.5</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -475,7 +475,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>5.2.1</tag>
+        <tag>5.5</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.5</version>
+    <version>5.6-SNAPSHOT</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -475,7 +475,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>5.5</tag>
+        <tag>5.2.1</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
+++ b/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
@@ -16,6 +16,7 @@ import no.digipost.api.representations.EbmsForsendelse;
 import no.digipost.api.representations.EbmsPullRequest;
 import no.digipost.api.representations.KanBekreftesSomBehandletKvittering;
 import no.digipost.api.representations.TransportKvittering;
+import org.springframework.ws.client.core.WebServiceTemplate;
 
 public class SikkerDigitalPostKlient {
 
@@ -41,6 +42,10 @@ public class SikkerDigitalPostKlient {
         this.databehandler = databehandler;
 
         CertificateValidator.validate(klientKonfigurasjon.getMiljo(), databehandler.noekkelpar.getVirksomhetssertifikat().getX509Certificate());
+    }
+
+    public WebServiceTemplate getMeldingTemplate() {
+        return digipostMessageSenderFacade.getMeldingTemplate();
     }
 
     /**

--- a/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
+++ b/src/main/java/no/difi/sdp/client2/SikkerDigitalPostKlient.java
@@ -44,10 +44,6 @@ public class SikkerDigitalPostKlient {
         CertificateValidator.validate(klientKonfigurasjon.getMiljo(), databehandler.noekkelpar.getVirksomhetssertifikat().getX509Certificate());
     }
 
-    public WebServiceTemplate getMeldingTemplate() {
-        return digipostMessageSenderFacade.getMeldingTemplate();
-    }
-
     /**
      * Sender en forsendelse til meldingsformidler. Dersom noe feilet i sendingen til meldingsformidler, vil det kastes en exception med beskrivende feilmelding.
      *
@@ -128,6 +124,22 @@ public class SikkerDigitalPostKlient {
      */
     public void setExceptionMapper(ExceptionMapper exceptionMapper) {
         this.digipostMessageSenderFacade.setExceptionMapper(exceptionMapper);
+    }
+
+    /**
+     * Hent ut Spring {@code WebServiceTemplate} som er konfigurert internt, og brukes av biblioteket
+     * til kommunikasjon med meldingsformidler. Ved hjelp av denne instansen kan man f.eks. sette opp en
+     * {@code MockWebServiceServer} for bruk i tester.
+     * <p>
+     * Man vil ikke under normale omstendigheter aksessere denne i produksjonskode.
+     *
+     * @return Spring {@code WebServiceTemplate} som er konfigurert internt i klientbiblioteket
+     *
+     * @see <a href="https://docs.spring.io/spring-ws/docs/3.0.7.RELEASE/reference/#_using_the_client_side_api">Spring WS - 6.2. Using the client-side API</a>
+     * @see <a href="https://docs.spring.io/spring-ws/docs/3.0.7.RELEASE/reference/#_client_side_testing">Spring WS - 6.3. Client-side testing</a>
+     */
+    public WebServiceTemplate getMeldingTemplate() {
+        return digipostMessageSenderFacade.getMeldingTemplate();
     }
 
 }

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -74,10 +74,6 @@ public class DigipostMessageSenderFacade {
         messageSender = messageSenderBuilder.build();
     }
 
-    public WebServiceTemplate getMeldingTemplate() {
-        return messageSender.getMeldingTemplate();
-    }
-
     public TransportKvittering send(final EbmsForsendelse ebmsForsendelse) {
         return performRequest(() -> messageSender.send(ebmsForsendelse));
     }
@@ -112,6 +108,10 @@ public class DigipostMessageSenderFacade {
 
     public void setExceptionMapper(final ExceptionMapper exceptionMapper) {
         this.exceptionMapper = exceptionMapper;
+    }
+
+    public WebServiceTemplate getMeldingTemplate() {
+        return messageSender.getMeldingTemplate();
     }
 
     protected ClientInterceptor payloadValidatingInterceptor() {

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -19,6 +19,7 @@ import no.digipost.api.representations.Organisasjonsnummer;
 import no.digipost.api.representations.TransportKvittering;
 import no.digipost.api.xml.Schemas;
 import org.apache.http.HttpRequestInterceptor;
+import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.client.support.interceptor.PayloadValidatingInterceptor;
 import org.springframework.ws.context.MessageContext;
@@ -71,6 +72,10 @@ public class DigipostMessageSenderFacade {
         }
 
         messageSender = messageSenderBuilder.build();
+    }
+
+    public WebServiceTemplate getMeldingTemplate() {
+        return messageSender.getMeldingTemplate();
     }
 
     public TransportKvittering send(final EbmsForsendelse ebmsForsendelse) {

--- a/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
+++ b/src/test/java/no/difi/sdp/client2/SikkerDigitalPostKlientTest.java
@@ -14,6 +14,7 @@ import static no.difi.sdp.client2.ObjectMother.forsendelse;
 import static no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig.UKJENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -68,4 +69,13 @@ public class SikkerDigitalPostKlientTest {
         assertThrows(SertifikatException.class, () -> new SikkerDigitalPostKlient(databehandlerWithTestCertificate, konfigurasjon));
     }
 
+    @Test
+    public void get_meldings_template_returns_not_null() {
+        KlientKonfigurasjon klientKonfigurasjon = KlientKonfigurasjon.builder(lokalTimeoutUrl)
+                .build();
+
+        SikkerDigitalPostKlient postklient = new SikkerDigitalPostKlient(databehandler(), klientKonfigurasjon);
+
+        assertThat(postklient.getMeldingTemplate(), notNullValue());
+    }
 }


### PR DESCRIPTION
Ved hjelp av denne instansen kan man f.eks. sette opp en `MockWebServiceServer` for bruk i tester.

Feature bidratt av https://github.com/FrodeBjerkholt
Ref pull-request: #80 