### PR TITLE
Support configuring SAAJ MessageFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>2.11</sdp-shared.version>
+        <sdp-shared.version>2.13</sdp-shared.version>
 
         <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.9-SNAPSHOT</version>
+    <version>5.9</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -443,7 +443,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>5.2.1</tag>
+        <tag>5.9</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.5.0-RC1</version>
+                <version>5.5.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>no.difi.sdp</groupId>
     <artifactId>sikker-digital-post-klient-java</artifactId>
-    <version>5.9</version>
+    <version>5.10-SNAPSHOT</version>
     <name>Sikker digital post-klient</name>
 
     <description>
@@ -443,7 +443,7 @@
         <connection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</connection>
         <developerConnection>scm:git:git@github.com:difi/sikker-digital-post-klient.git</developerConnection>
         <url>scm:git:git@github.com:difi/sikker-digital-post-klient</url>
-        <tag>5.9</tag>
+        <tag>5.2.1</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/difi/sdp/client2/KlientKonfigurasjon.java
+++ b/src/main/java/no/difi/sdp/client2/KlientKonfigurasjon.java
@@ -2,6 +2,7 @@ package no.difi.sdp.client2;
 
 import no.difi.sdp.client2.domain.Miljo;
 import no.digipost.api.EbmsEndpointUriBuilder;
+import no.digipost.api.MessageFactorySupplier;
 import no.digipost.api.representations.Organisasjonsnummer;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponseInterceptor;
@@ -42,11 +43,16 @@ public class KlientKonfigurasjon {
     private ClientInterceptor[] soapInterceptors = new ClientInterceptor[0];
     private HttpRequestInterceptor[] httpRequestInterceptors = new HttpRequestInterceptor[0];
     private HttpResponseInterceptor[] httpResponseInterceptors = new HttpResponseInterceptor[0];
+    private MessageFactorySupplier messageFactorySupplier;
 
 
 
     private KlientKonfigurasjon(Miljo miljo) {
         this.miljo = miljo;
+    }
+
+    public MessageFactorySupplier getSoapMessageFactorySupplier() {
+        return MessageFactorySupplier.defaultIfNull(messageFactorySupplier);
     }
 
     public String getProxyHost() {
@@ -112,6 +118,11 @@ public class KlientKonfigurasjon {
 
         private Builder(Miljo miljo){
             target = new KlientKonfigurasjon(miljo);
+        }
+
+        public Builder soapMessageFactorySupplier(MessageFactorySupplier messageFactorySupplier) {
+            target.messageFactorySupplier = messageFactorySupplier;
+            return this;
         }
 
         public Builder proxy(String proxyHost, int proxyPort) {

--- a/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
+++ b/src/main/java/no/difi/sdp/client2/internal/DigipostMessageSenderFacade.java
@@ -51,6 +51,7 @@ public class DigipostMessageSenderFacade {
                 .withSocketTimeout((int) klientKonfigurasjon.getSocketTimeoutInMillis())
                 .withConnectionRequestTimeout((int) klientKonfigurasjon.getConnectionRequestTimeoutInMillis())
                 .withDefaultMaxPerRoute(klientKonfigurasjon.getMaxConnectionPoolSize())
+                .withSoapMessageFactorySupplier(klientKonfigurasjon.getSoapMessageFactorySupplier())
                 .withMaxTotal(klientKonfigurasjon.getMaxConnectionPoolSize());
 
         if (klientKonfigurasjon.useProxy()) {


### PR DESCRIPTION
The new sdp-api-client v2.13 will use [EE4J Metro SAAJ-RI](https://github.com/eclipse-ee4j/metro-saaj) by default, but also supports configuring to use whatever the runtime is configured to provide through standard mechanism using [`javax.xml.soap.MessageFactory.newInstance(..)`](https://docs.oracle.com/javase/8/docs/api/javax/xml/soap/MessageFactory.html#newInstance-java.lang.String-).

Previous versions of this library used `MessageFactory.newInstance(..)` and provided Metro SAAJ-RI on the classpath to have the discovery mechanism of the JDK to use it, but in rare circumstances this could fail, and the JDK-bundled SAAJ implementation was chosen instead. See [sdp-shared v2.13](https://github.com/digipost/sdp-shared/releases/tag/2.13) for further details on the motivation to change this to be more "insisting" on Metro SAAJ-RI.