### PR TITLE
Update 0_sende_post.md

### DIFF
--- a/docs/_v5/0_sende_post.md
+++ b/docs/_v5/0_sende_post.md
@@ -98,7 +98,7 @@ Forsendelse forsendelse = Forsendelse
 ### Utvidelser
 Difi har egne dokumenttyper, eller utvidelser, som kan sendes som metadata til hoveddokumenter. Disse utvidelsene er strukturerte xml-dokumenter
 med egne mime-typer. Disse utvidelsene benyttes av postkasseleverandørene til å gi en øket brukeropplevelse for innbyggere.
-Les mer om utvidelser på [https://begrep.difi.no/SikkerDigitalPost/](https://begrep.difi.no/SikkerDigitalPost/)
+Les mer om utvidelser på [https://difi.github.io/felleslosninger/](https://difi.github.io/felleslosninger/sdp_utvidelser_index.html)
 
 Utvidelsene ligger som generert kode i `sdp-shared`, som er en avhengighet av `sikker-digital-post-klient-java`. Du kan selv lage kode
 for å generere xml fra instanser av disse typene med JAXB, eller du kan lage xml på andre måter.


### PR DESCRIPTION
Rettet lenke til utvidelser siden dokumentasjon på begrep.difi.no er flyttet til https://difi.github.io/felleslosninger/