### PR TITLE
Upgrade spring-security-core to get rid of CWE-862

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -193,9 +193,14 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.3.18</version>
+                <version>5.3.19</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>5.6.3</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -315,7 +320,14 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.sonatype.ossindex.maven</groupId>
+                            <artifactId>ossindex-maven-enforcer-rules</artifactId>
+                            <version>3.2.0</version>
+                        </dependency>                    
+                    </dependencies>
                     <configuration>
                         <rules>
                             <bannedDependencies>
@@ -378,6 +390,7 @@
                                      https://maven.apache.org/docs/3.3.1/release-notes.html -->
                                 <version>3.3.1</version>
                             </requireMavenVersion>
+                            <banVulnerable implementation="org.sonatype.ossindex.maven.enforcer.BanVulnerableDependencies"/>
                         </rules>
                     </configuration>
                 </plugin>

--- a/lib/src/main/java/no/difi/sdp/client2/domain/MetadataDokument.java
+++ b/lib/src/main/java/no/difi/sdp/client2/domain/MetadataDokument.java
@@ -1,6 +1,7 @@
 package no.difi.sdp.client2.domain;
 
 import no.difi.sdp.client2.asice.AsicEAttachable;
+
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -37,7 +38,7 @@ public class MetadataDokument implements AsicEAttachable {
 
     /**
      * @param filnavn  Tittel som vises til brukeren gitt riktig sikkerhetsnivå.
-     * @param filnavn  Filnavnet til dokumentet.
+     * @param mimetype  Filnavnet til dokumentet.
      * @param dokument Filen som skal sendes. Navnet på filen vil brukes som filnavn ovenfor mottaker.
      */
     public static Builder builder(String filnavn, String mimetype, byte[] dokument) {
@@ -81,7 +82,9 @@ public class MetadataDokument implements AsicEAttachable {
         }
 
         public MetadataDokument build() {
-            if (built) throw new IllegalStateException("Can't build twice");
+            if (built) {
+                throw new IllegalStateException("Can't build twice");
+            }
             built = true;
             return target;
         }


### PR DESCRIPTION
reported by Sonatype Lift.

Also uprade Spring Framework to latest version, and configure the
maven-enforcer rule banVulnerable to make it easier to detect
vulnerabilities at build time.

(MetadataDokument.java) Fix a parameter naming error (CLI warning) in
JavaDoc.